### PR TITLE
Add examples/repo/scripts-dir-*

### DIFF
--- a/examples/index.yml
+++ b/examples/index.yml
@@ -1,0 +1,23 @@
+#@data/values
+---
+#@overlay/match missing_ok=True
+
+#! <OPTIONAL> if your pipeline needs to run with DB
+db_flavors:
+- image: postgres
+  value: postgres
+- image: mysql-8.0
+  value: mysql
+- image: mysql-5.7
+  value: mysql
+
+#! <MUST> repo/component/package to test in your repo/release
+internal_repos:
+- name: <REPLACE_ME> #! <MUST> e.g. "bosh-dns-adapter"
+  repo: <REPLACE_ME> #! <OPTIONAL> (Defaults to repo) This is only needed when we are locking two repo under the same pipeline. e.g. silk-release and cf-networking-release e.g. cf-networking-repo
+  configure_db: <REPLACE_ME> #! <OPTIONAL> (Defaults to false) Set to "true" if you'd like the run-bin-test to automatically configure_db before running tests.
+  privileged: <REPLACE_ME>  #! <OPTIONAL> (Defaults to false) Set to "true" if you need the test run in a privileged container
+
+#! <OPTIONAL> set to a list of opsfile if pipeline needs to update cf-deployment
+opsfiles:
+- <REPLACE_ME> #! e.g. use-compiled-releases.yml

--- a/examples/repo/scripts-dir-generic/create-docker-container.bash
+++ b/examples/repo/scripts-dir-generic/create-docker-container.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
+REPO_PATH="${THIS_FILE_DIR}/../"
+unset THIS_FILE_DIR
+
+IMAGE="cloudfoundry/tas-runtime-build"
+
+if [[ -z "${*}" ]]; then
+  ARGS="-it"
+else
+  ARGS="${*}"
+fi
+
+echo $ARGS
+
+docker pull "${IMAGE}"
+docker rm -f "$REPO_NAME-docker-container"
+docker run -it \
+  --env "REPO_NAME=$REPO_NAME" \
+  --env "REPO_PATH=/repo" \
+  --name "$REPO_NAME-docker-container" \
+  -v "${REPO_PATH}:/repo" \
+  -v "${CI}:/ci" \
+   <REPLACE_ME> or --privileged \ #Needed for releases that need containers with elavated permissions
+   <REPLACE_ME> or --cap-add ALL \
+  ${ARGS} \
+  "${IMAGE}" \
+  /bin/bash
+  

--- a/examples/repo/scripts-dir-generic/docker/README.md
+++ b/examples/repo/scripts-dir-generic/docker/README.md
@@ -1,0 +1,3 @@
+# Docker Scripts
+
+To learn more about these scripts, go to the main [README](../..//README.md).

--- a/examples/repo/scripts-dir-generic/docker/build-binaries.bash
+++ b/examples/repo/scripts-dir-generic/docker/build-binaries.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. "/ci/shared/helpers/git-helpers.bash"
+
+pushd /repo > /dev/null
+git_configure_safe_directory
+REPO_NAME=$(git_get_remote_name)
+popd > /dev/null
+
+. <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/build-binaries/linux.yml)
+
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/build-binaries/linux.yml"
+pushd / > /dev/null
+/ci/shared/tasks/build-binaries/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-generic/docker/lint.bash
+++ b/examples/repo/scripts-dir-generic/docker/lint.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/lint-repo/linux.yml)
+
+pushd / > /dev/null
+/ci/shared/tasks/lint-repo/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-generic/docker/test.bash
+++ b/examples/repo/scripts-dir-generic/docker/test.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. "/ci/shared/helpers/git-helpers.bash"
+
+function test() {
+  local package="${1:?Provide a package}"
+  local sub_package="${2:-}"
+
+  export DIR=${package}
+  . <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/run-bin-test/linux.yml)
+
+  export GOFLAGS="-buildvcs=false"
+  /ci/shared/tasks/run-bin-test/task.bash "${sub_package}"
+}
+
+pushd /repo > /dev/null
+git_configure_safe_directory
+REPO_NAME=$(git_get_remote_name)
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/run-bin-test/linux.yml"
+popd > /dev/null
+
+pushd / > /dev/null
+if [[ -n "${1:-}" ]]; then
+  test "src/code.cloudfoundry.org/${1}" "${2:-}"
+else
+  internal_repos=$(yq -r '.internal_repos|.[].name' "/ci/$REPO_NAME/index.yml")
+  for component in $internal_repos; do
+    test "src/code.cloudfoundry.org/${component}"
+  done
+fi
+popd > /dev/null

--- a/examples/repo/scripts-dir-generic/docker/tests-templates.bash
+++ b/examples/repo/scripts-dir-generic/docker/tests-templates.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+pushd / > /dev/null
+/ci/shared/tasks/run-tests-templates/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-generic/test-in-docker-locally.bash
+++ b/examples/repo/scripts-dir-generic/test-in-docker-locally.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eu
+
+THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
+
+"${THIS_FILE_DIR}/create-docker-container.bash" -d
+
+# <REPLACE_ME> If your release need to build-binaries as part of tests, uncomment below
+#docker exec $REPO_NAME-docker-container '/repo/scripts/docker/build-binaries.bash'
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/tests-templates.bash'
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/test.bash' "$@"
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/lint.bash'

--- a/examples/repo/scripts-dir-with-db/create-docker-container.bash
+++ b/examples/repo/scripts-dir-with-db/create-docker-container.bash
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
+REPO_PATH="${THIS_FILE_DIR}/../"
+unset THIS_FILE_DIR
+
+if [[ ${DB:-empty} == "empty" ]]; then
+  DB=mysql
+fi
+
+if [[ "${DB}" == "mysql" ]] || [[ "${DB}" == "mysql-8.0" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-mysql-8.0"
+  DB="mysql"
+elif [[ "${DB}" == "mysql-5.7" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-mysql-5.7"
+  DB="mysql"
+elif [[ "${DB}" == "postgres" ]]; then
+  IMAGE="cloudfoundry/tas-runtime-postgres"
+else
+  echo "Unsupported DB flavor"
+  exit 1
+fi
+
+if [[ -z "${*}" ]]; then
+  ARGS="-it"
+else
+  ARGS="${*}"
+fi
+
+echo $ARGS
+
+docker pull "${IMAGE}"
+docker rm -f "$REPO_NAME-docker-container"
+docker run -it \
+  --env "DB=${DB}" \
+  --env "REPO_NAME=$REPO_NAME" \
+  --env "REPO_PATH=/repo" \
+  --name "$REPO_NAME-docker-container" \
+  -v "${REPO_PATH}:/repo" \
+  -v "${CI}:/ci" \
+   <REPLACE_ME> or --privileged \ #Needed for releases that need containers with elavated permissions
+   <REPLACE_ME> or --cap-add ALL \
+  ${ARGS} \
+  "${IMAGE}" \
+  /bin/bash
+  

--- a/examples/repo/scripts-dir-with-db/docker/README.md
+++ b/examples/repo/scripts-dir-with-db/docker/README.md
@@ -1,0 +1,3 @@
+# Docker Scripts
+
+To learn more about these scripts, go to the main [README](../..//README.md).

--- a/examples/repo/scripts-dir-with-db/docker/build-binaries.bash
+++ b/examples/repo/scripts-dir-with-db/docker/build-binaries.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. "/ci/shared/helpers/git-helpers.bash"
+
+pushd /repo > /dev/null
+git_configure_safe_directory
+REPO_NAME=$(git_get_remote_name)
+popd > /dev/null
+
+. <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/build-binaries/linux.yml)
+
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/build-binaries/linux.yml"
+pushd / > /dev/null
+/ci/shared/tasks/build-binaries/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-with-db/docker/lint.bash
+++ b/examples/repo/scripts-dir-with-db/docker/lint.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/lint-repo/linux.yml)
+
+pushd / > /dev/null
+/ci/shared/tasks/lint-repo/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-with-db/docker/test.bash
+++ b/examples/repo/scripts-dir-with-db/docker/test.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+. "/ci/shared/helpers/git-helpers.bash"
+
+function test() {
+  local package="${1:?Provide a package}"
+  local sub_package="${2:-}"
+
+  export DIR=${package}
+  . <(/ci/shared/helpers/extract-default-params-for-task.bash /ci/shared/tasks/run-bin-test/linux.yml)
+
+  export GOFLAGS="-buildvcs=false"
+  export DB="${DB}"
+  /ci/shared/tasks/run-bin-test/task.bash "${sub_package}"
+}
+
+pushd /repo > /dev/null
+git_configure_safe_directory
+REPO_NAME=$(git_get_remote_name)
+export DEFAULT_PARAMS="/ci/$REPO_NAME/default-params/run-bin-test/linux.yml"
+popd > /dev/null
+
+pushd / > /dev/null
+if [[ -n "${1:-}" ]]; then
+  test "src/code.cloudfoundry.org/${1}" "${2:-}"
+else
+  internal_repos=$(yq -r '.internal_repos|.[].name' "/ci/$REPO_NAME/index.yml")
+  for component in $internal_repos; do
+    test "src/code.cloudfoundry.org/${component}"
+  done
+fi
+popd > /dev/null

--- a/examples/repo/scripts-dir-with-db/docker/tests-templates.bash
+++ b/examples/repo/scripts-dir-with-db/docker/tests-templates.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu
+set -o pipefail
+
+pushd / > /dev/null
+/ci/shared/tasks/run-tests-templates/task.bash
+popd > /dev/null

--- a/examples/repo/scripts-dir-with-db/test-in-docker-locally.bash
+++ b/examples/repo/scripts-dir-with-db/test-in-docker-locally.bash
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -eu
+
+THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+CI="${THIS_FILE_DIR}/../../wg-app-platform-runtime-ci"
+. "$CI/shared/helpers/git-helpers.bash"
+REPO_NAME=$(git_get_remote_name)
+
+if [[ ${DB:-empty} == "empty" ]]; then
+  DB=mysql
+fi
+
+DB="${DB}" "${THIS_FILE_DIR}/create-docker-container.bash" -d
+
+# <REPLACE_ME> If your release need to build-binaries as part of tests, uncomment below
+#docker exec $REPO_NAME-docker-container '/repo/scripts/docker/build-binaries.bash'
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/tests-templates.bash'
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/test.bash' "$@"
+docker exec $REPO_NAME-docker-container '/repo/scripts/docker/lint.bash'

--- a/healthchecker-release/index.yml
+++ b/healthchecker-release/index.yml
@@ -2,4 +2,4 @@
 ---
 #@overlay/match missing_ok=True
 internal_repos:
-- "healthchecker"
+- name: "healthchecker"

--- a/nats-release/index.yml
+++ b/nats-release/index.yml
@@ -2,7 +2,7 @@
 ---
 #@overlay/match missing_ok=True
 internal_repos:
-- "nats-v2-migrate"
+- name: "nats-v2-migrate"
 opsfiles:
 - add-lb-ca-cert.yml
 - scale-for-cats.yml

--- a/routing-release/index.yml
+++ b/routing-release/index.yml
@@ -2,13 +2,13 @@
 ---
 #@overlay/match missing_ok=True
 internal_repos:
-- "gorouter"
-- "cf-tcp-router"
-- "multierror"
-- "route-registrar"
-- "routing-api"
-- "routing-api-cli"
-- "routing-info"
+- name: "gorouter"
+- name: "cf-tcp-router"
+- name: "multierror"
+- name: "route-registrar"
+- name: "routing-api"
+- name: "routing-api-cli"
+- name: "routing-info"
 opsfiles:
 - add-lb-ca-cert.yml
 - scale-for-cats.yml

--- a/shared/helpers/ytt-helpers.star
+++ b/shared/helpers/ytt-helpers.star
@@ -1,0 +1,36 @@
+load("@ytt:struct", "struct")
+
+def packages_with_configure_db(packages = []):
+    l = []
+ for p in packages:
+     if hasattr(p, "configure_db"):
+         if p.configure_db:
+             l.append(p)
+     end
+   end
+ end
+ return l
+end
+
+def packages_without_configure_db(packages = []):
+    l = []
+ for p in packages:
+     if not hasattr(p, "configure_db"):
+         l.append(p)
+   elif not p.configure_db:
+       l.append(p)
+   end
+ end
+ return l
+end
+
+def privileged(package):
+    if hasattr(package, "privileged"):
+        if package.privileged:
+            return True
+  end
+ end
+ return False
+end
+
+helpers = struct.make(packages_with_configure_db=packages_with_configure_db, packages_without_configure_db=packages_without_configure_db, privileged=privileged)

--- a/shared/tasks/build-binaries/task.bash
+++ b/shared/tasks/build-binaries/task.bash
@@ -6,7 +6,8 @@ set -o pipefail
 THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export TASK_NAME="$(basename $THIS_FILE_DIR)"
 source "$THIS_FILE_DIR/../../../shared/helpers/helpers.bash"
-if [[ -n "${DEFAULT_PARAMS:-}" ]]; then
+if [[ -n "${DEFAULT_PARAMS:-}" ]] && [[ -f "${DEFAULT_PARAMS}" ]]; then
+    debug "extract-default-params-for-task with values from ${DEFAULT_PARAMS}"
     . <("$THIS_FILE_DIR/../../../shared/helpers/extract-default-params-for-task.bash" "${DEFAULT_PARAMS}")
 fi
 unset THIS_FILE_DIR

--- a/shared/tasks/lint-ci/task.bash
+++ b/shared/tasks/lint-ci/task.bash
@@ -194,6 +194,8 @@ function allowed_dirs() {
     dir_patterns="$(cat <<EOF
 ^./bin/*$
 ^./examples/(task|pipeline)*$
+^./examples/repo/(scripts-dir-with-db|scripts-dir-generic)$
+^./examples/repo/(scripts-dir-with-db|scripts-dir-generic)/docker$
 ^./(shared|${release_list})/(helpers|opsfiles|linters)$
 ^./(shared|${release_list})/tasks/[a-z\-]*$
 ^./(${release_list})/(manifests)$

--- a/shared/tasks/run-bin-test/task.bash
+++ b/shared/tasks/run-bin-test/task.bash
@@ -6,7 +6,8 @@ set -o pipefail
 THIS_FILE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export TASK_NAME="$(basename $THIS_FILE_DIR)"
 source "$THIS_FILE_DIR/../../../shared/helpers/helpers.bash"
-if [[ -n "${DEFAULT_PARAMS:-}" ]]; then
+if [[ -n "${DEFAULT_PARAMS:-}" ]] && [[ -f "${DEFAULT_PARAMS}" ]]; then
+    debug "extract-default-params-for-task with values from ${DEFAULT_PARAMS}"
     . <("$THIS_FILE_DIR/../../../shared/helpers/extract-default-params-for-task.bash" "${DEFAULT_PARAMS}")
 fi
 unset THIS_FILE_DIR


### PR DESCRIPTION
For configuring repo's script's directory. Most of these examples are meant to be copied over and tuned for a specific releases. Look for "REPLACE_ME" after copying the example and replace as needed.

Move index.yml internal_repos to an array of objects, so that cf-networking-releae and silk-release's pipline will continue to work. Also added an example/index.yml when creating a new index.yml for a new repo.

Added helper ytt function for parsing internal_repos and when configuring tests so that the pipeline loop is more generic and re-usable across pielines.