### PR TITLE
Use shepherd instead of toolsmiths for winc-release in test pipeline

### DIFF
--- a/winc-release/tasks/create-iwa-vars-file/task.bash
+++ b/winc-release/tasks/create-iwa-vars-file/task.bash
@@ -13,9 +13,9 @@ function run(){
     shift 1
 
     cat <<EOF > created-iwa-vars-file/"${FILENAME}"
-iwa_dc_ips: ${IWA_DC_IPS}
+iwa_dc_ips: "${IWA_DC_IPS}"
 iwa_plugin_input: ${IWA_PLUGIN_INPUT}
-iwa_credential_spec: ${IWA_CREDENTIAL_SPEC}
+iwa_credential_spec: "${IWA_CREDENTIAL_SPEC}"
 EOF
 }
 

--- a/winc-release/tasks/create-iwa-vars-file/task.bash
+++ b/winc-release/tasks/create-iwa-vars-file/task.bash
@@ -15,7 +15,8 @@ function run(){
     cat <<EOF > created-iwa-vars-file/"${FILENAME}"
 iwa_dc_ips: "${IWA_DC_IPS}"
 iwa_plugin_input: ${IWA_PLUGIN_INPUT}
-iwa_credential_spec: "${IWA_CREDENTIAL_SPEC}"
+iwa_credential_spec: |
+    ${IWA_CREDENTIAL_SPEC}
 EOF
 }
 


### PR DESCRIPTION
- WIP adding extra vars
- add create-file task
- use (some) compiled releases for winc-release
- add create iwa vars task for winc-release
- WIP
- WIP
