### PR TITLE
Move garden-runc-release garden-windows.yml to wg ci winc-release

### DIFF
--- a/winc-release/manifests/gatsw-pesto.yml
+++ b/winc-release/manifests/gatsw-pesto.yml
@@ -1,0 +1,76 @@
+---
+name: ((DEPLOYMENT_NAME))
+
+releases:
+- name: garden-runc
+  version: latest
+- name: winc
+  version: latest
+- name: windows-utilities
+  version: latest
+- name: garden-ci-artifacts
+  version: latest
+
+stemcells:
+- alias: windows2019
+  os: windows2019
+  version: latest
+- alias: stemcell
+  os: ((CF_STEMCELL_OS))
+  version: latest
+
+instance_groups:
+- name: gats
+  instances: 1
+  lifecycle: errand
+  vm_type: ((CF_VM_TYPE))
+  networks:
+  - name: ((CF_NETWORK))
+  azs: [((CF_AZ))]
+  stemcell: stemcell
+  jobs:
+  - name: gats
+    release: garden-runc
+    properties:
+      windows_rootfs: docker://mcr.microsoft.com/windows/nanoserver:ltsc2019
+- name: garden-windows
+  instances: 1
+  vm_type: small-highmem
+  vm_extensions:
+    - 100GB_ephemeral_disk
+  stemcell: windows2019
+  azs: [((CF_AZ))]
+  networks:
+  - name: ((CF_NETWORK))
+  jobs:
+  - name: enable_ssh
+    release: windows-utilities
+  - name: garden-plugins
+    release: garden-ci-artifacts
+  - name: garden-windows
+    release: garden-runc
+    properties:
+      garden:
+        runtime_plugin: C:\var\vcap\packages\winc\winc.exe
+        image_plugin: C:\var\vcap\packages\groot\groot.exe
+        image_plugin_extra_args:
+        - "--driver-store"
+        - C:\var\vcap\data\groot
+        network_plugin: C:\var\vcap\packages\noop_plugin\noop_plugin.exe
+        nstar_bin: C:\var\vcap\packages\noop_plugin\noop_plugin.exe
+        listen_address: 0.0.0.0:7777
+        default_container_rootfs: docker://mcr.microsoft.com/windows/nanoserver:ltsc2019
+        destroy_containers_on_start: true
+  - name: winc
+    release: winc
+  - name: groot
+    release: winc
+    properties:
+      groot:
+        driver_store: C:\var\vcap\data\groot
+
+update:
+  canaries: 1
+  max_in_flight: 3
+  canary_watch_time: 1000-240000
+  update_watch_time: 1000-240000


### PR DESCRIPTION
Found that this manifest was deleted from `garden-runc-release`, but is required for the `winc-release` pipeline.
We only need this due to the existence of the `pesto` environment.  Once migrated to shepherd we should be able to delete this and use [this gats manifest](https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/shared/manifests/gatsw.yml)