### PR TITLE
create-envoy-blob: run cleanup at end of task

### DIFF
--- a/diego-release/tasks/create-envoy-blob/task.bash
+++ b/diego-release/tasks/create-envoy-blob/task.bash
@@ -41,7 +41,7 @@ function copy_file {
   scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i /tmp/id_rsa_gcp "pivotal@${ip}:${filename}" "${destination}"
 }
 
-# trap cleanup EXIT // TODO remove; commented out to make sure we save test logs.
+trap cleanup EXIT
 
 ssh-keygen -N "" -f /tmp/id_rsa_gcp
 


### PR DESCRIPTION
A few months ago, we stopped cleaning up the terraformed compilation vm so that we could inspect the logs:
- https://github.com/pivotal/tas-runtime/commit/eba0b625323b220aa74a168ae4a3a4e073158866

We never reverted this change and accidentally brought it over with us.