### PR TITLE
Clean up after go build

### DIFF
--- a/diego-release/helpers/build-binaries.ps1
+++ b/diego-release/helpers/build-binaries.ps1
@@ -27,4 +27,5 @@ function Build-Nats-Server
 
     $PS1FILE='$env:NATS_SERVER_BINARY="$PWD/{0}"' -f "$BuiltDir\nats-server\run.exe" 
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }

--- a/envoy-nginx-release/helpers/build-binaries.ps1
+++ b/envoy-nginx-release/helpers/build-binaries.ps1
@@ -32,4 +32,5 @@ function Build-Proxy
 
         $PS1FILE='$env:PROXY_BINARY="$PWD/{0}"' -f "$BuiltDir/proxy/envoy.exe"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }

--- a/garden-runc-release/helpers/build-binaries.ps1
+++ b/garden-runc-release/helpers/build-binaries.ps1
@@ -27,6 +27,7 @@ function Build-Winit
     Pop-Location
     $PS1FILE='$env:WINIT_BINARY="$PWD/{0}"' -f "$BuiltDir/winit/run.exe"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }
 
 function Build-Gdn
@@ -61,4 +62,5 @@ $env:GDN_ERR_LOG_FILE="$PWD/{2}"
 $env:GDN_BIND_IP="127.0.0.1"
 $env:GDN_BIND_PORT=8888' -f "$BuiltDir/gdn/run.exe", "$BuiltDir/gdn/out.log", "$BuiltDir/gdn/err.log"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }

--- a/shared/helpers/helpers.ps1
+++ b/shared/helpers/helpers.ps1
@@ -69,6 +69,13 @@ function Verify-Ginkgo {
   Pop-Location
 }
 
+function Clean-GoCache{
+  go.exe clean -cache
+  if ($LastExitCode -ne 0) {
+    exit 1
+  }
+}
+
 function Set-TemporaryDirectory {
     $env:TEMP="/var/vcap/data/tmp"
     $env:TMP="/var/vcap/data/tmp"

--- a/shared/tasks/build-binaries/task.ps1
+++ b/shared/tasks/build-binaries/task.ps1
@@ -21,6 +21,7 @@ function Run
         Write-Host "Executing: $Function -Source $Source -Target $Target"
         & $Function -Source $Source -Target "$Target"
     }
+    Clean-GoCache
 }
 
 Run

--- a/winc-release/helpers/build-binaries.ps1
+++ b/winc-release/helpers/build-binaries.ps1
@@ -43,6 +43,7 @@ $env:GROOT_IMAGE_STORE="\var\vcap\data\tmp\groot"
 $env:GROOT_CONFIG="$PWD/{1}"
 $env:GROOT_QUOTA_DLL="$PWD/{2}"' -f "$BuiltDir\groot-windows\run.exe", "$BuiltDir/groot-windows/config.yml", "$BuiltDir/groot-windows/quota.dll"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }
 
 function Build-Winc-Network
@@ -77,6 +78,7 @@ function Build-Winc-Network
 $env:WINC_NETWORK_CONFIG="$PWD/{1}"
 $env:WINC_NETWORK_LOG_FILE="$PWD/{2}"' -f "$BuiltDir/winc-network/run.exe","$BuiltDir/winc-network/config.json", "$BuiltDir/winc-network/out.log"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }
 
 function Build-Winc
@@ -107,6 +109,7 @@ function Build-Winc
     Pop-Location
         $PS1FILE='$env:WINC_BINARY="$PWD/{0}"' -f "$BuiltDir/winc/run.exe"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }
 
 function Build-Nstar
@@ -136,6 +139,7 @@ function Build-Nstar
     Pop-Location
         $PS1FILE='$env:NSTAR_BINARY="$PWD/{0}"' -f "$BuiltDir/nstar/run.exe"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }
 
 function Build-Diff-Exporter
@@ -165,4 +169,5 @@ function Build-Diff-Exporter
     Pop-Location
         $PS1FILE='$env:DIFF_EXPORTER_BINARY="$PWD/{0}"' -f "$BuiltDir/diff-exporter/run.exe"
         Set-Content -Path "$Target/run.ps1" -Value $PS1FILE -Encoding Asci
+        Clean-GoCache
 }


### PR DESCRIPTION
After binaries get built, the GOCACHE path is incorrectly set to be on
the local C: drive.  By cleaning the Cache after the binaries are built
we will eliminate the need to recreate our windows workers every
week.
