### PR TITLE
Change dependency go mod bumping from 1 week to 24h

### DIFF
--- a/cf-networking-release/pipelines/cf-networking-release.yml
+++ b/cf-networking-release/pipelines/cf-networking-release.yml
@@ -143,11 +143,11 @@ resources:
     tag_filter: v*
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 - name: env
   type: shepherd
@@ -233,7 +233,7 @@ jobs:
       - get: cf-networking-repo
       - get: silk-repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - in_parallel:
     - do:

--- a/cpu-entitlement-plugin/pipelines/cpu-entitlement-plugin.yml
+++ b/cpu-entitlement-plugin/pipelines/cpu-entitlement-plugin.yml
@@ -89,11 +89,11 @@ resources:
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 daily
 
 - name: env
   type: shepherd
@@ -154,7 +154,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: cpu-entitlement-plugin-bump-dependencies-go-mod
     image: image

--- a/diego-release/pipelines/diego-release.yml
+++ b/diego-release/pipelines/diego-release.yml
@@ -167,11 +167,11 @@ resources:
     tag_filter: v0.285.0
 
 #! TIMERS
-- name: weekly
+- name: daily 
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 - name: env
   type: shepherd
@@ -260,7 +260,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: diego-release-bump-dependencies-go-mod
     image: image

--- a/envoy-nginx-release/pipelines/envoy-nginx-release.yml
+++ b/envoy-nginx-release/pipelines/envoy-nginx-release.yml
@@ -106,11 +106,11 @@ resources:
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
 
 #! TIMERS
-- name: weekly
+- name: daily 
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day 
 
 - name: env
   type: shepherd
@@ -179,7 +179,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: envoy-nginx-release-bump-dependencies-go-mod
     image: image

--- a/examples/pipeline/example.yml
+++ b/examples/pipeline/example.yml
@@ -114,11 +114,11 @@ resources:
     paths: [go-version.json]
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Toolsmith pool
 - name: env
@@ -188,7 +188,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - task: <REPLACE_ME>-bump-dependencies-go-mod
     image: image

--- a/garden-runc-release/pipelines/garden-runc-release.yml
+++ b/garden-runc-release/pipelines/garden-runc-release.yml
@@ -208,11 +208,11 @@ resources:
     paths: [go-version.json]
 
 #! TIMERS
-- name: weekly
+- name: daily 
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Toolsmith pool
 - name: env
@@ -417,7 +417,7 @@ jobs:
     - get: updated-go-mod-dontpanic
     - get: updated-go-mod-netplugin-shim
     - get: image
-    - get: weekly
+    - get: daily
       trigger: true
   - do:
     - task: garden-bump-dependencies-go-mod

--- a/healthchecker-release/pipelines/healthchecker-release.yml
+++ b/healthchecker-release/pipelines/healthchecker-release.yml
@@ -83,11 +83,11 @@ resources:
     paths: [go-version.json]
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day 
 
 - name: env
   type: shepherd
@@ -150,7 +150,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - task: healthchecker-release-bump-dependencies-go-mod
     image: image

--- a/nats-release/pipelines/nats-release.yml
+++ b/nats-release/pipelines/nats-release.yml
@@ -107,11 +107,11 @@ resources:
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! shephard
 - name: env
@@ -175,7 +175,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: nats-release-bump-dependencies-go-mod
     image: image

--- a/routing-release/pipelines/routing-release.yml
+++ b/routing-release/pipelines/routing-release.yml
@@ -168,11 +168,11 @@ resources:
     name: bosh-google-kvm-ubuntu-bionic-go_agent
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Deployment Environment pool
 - name: env
@@ -265,7 +265,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - task: routing-release-bump-dependencies-go-mod
     image: image

--- a/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
+++ b/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
@@ -43,11 +43,11 @@ resources:
     uri: https://github.com/bosh-packages/golang-release.git
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Define-Jobs
 jobs:
@@ -146,7 +146,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/wg-arp-garden-modules/pipelines/wg-arp-garden-modules.yml
+++ b/wg-arp-garden-modules/pipelines/wg-arp-garden-modules.yml
@@ -77,11 +77,11 @@ resources:
     access_token: ((github-tas-runtime-bot/access-token))
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Define-Jobs
 jobs:
@@ -246,7 +246,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
+++ b/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
@@ -50,11 +50,11 @@ resources:
     uri: https://github.com/bosh-packages/golang-release.git
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day 
 
 #! Define-Jobs
 jobs:
@@ -176,7 +176,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/winc-release/pipelines/winc-release.yml
+++ b/winc-release/pipelines/winc-release.yml
@@ -201,11 +201,11 @@ resources:
     uri: git@github.com:pivotal/garden-windows-environments
 
 #! TIMERS
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 - name: github-release
   source:
@@ -297,7 +297,7 @@ jobs:
       - get: updated-go-mod-diff-exporter
       - get: updated-go-mod-groot-windows
       - get: updated-go-mod-winc
-      - get: weekly
+      - get: daily
         trigger: true
   - do:
     - task: cert-injector-bump-dependencies-go-mod

--- a/windows2019fs-release/pipelines/windows2019fs-release.yml
+++ b/windows2019fs-release/pipelines/windows2019fs-release.yml
@@ -152,11 +152,11 @@ resources:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24h'  #! 1 day
 
 #! Define-Jobs
 jobs:
@@ -168,7 +168,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily
         trigger: true
   - task: windows2019fs-release-bump-dependencies-go-mod
     image: image

--- a/windowsfs-online-release/pipelines/windowsfs-online-release.yml
+++ b/windowsfs-online-release/pipelines/windowsfs-online-release.yml
@@ -152,11 +152,11 @@ resources:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
-- name: weekly
+- name: daily
   type: time
   icon: clock
   source:
-    interval: '168h'  #! 1 week
+    interval: '24'  #! 1 day 
 
 #! Define-Jobs
 jobs:
@@ -168,7 +168,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily 
         trigger: true
   - task: windowsfs-online-bump-dependencies-go-mod
     image: image


### PR DESCRIPTION
Making this change to stay ahead of dependabot's PR's. Ideally, I'd like to keep dependabot as a doublecheck to ensure we're bumping everything that we need to bump.