### PR TITLE
Workaround docker layering issue for nginx

### DIFF
--- a/shared/dockerfiles/tas-runtime-mysql-5.7/Dockerfile
+++ b/shared/dockerfiles/tas-runtime-mysql-5.7/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     lsof \
     mercurial \
     netcat \
+    nginx \
     procps \
     psmisc \
     python \


### PR DESCRIPTION
nginx isn't showing up in the mysql  5.7 image.  forcibly putting it there. I suspect this may be related to a docker layering issue that needs to be triaged and troubleshot.