### PR TITLE
Update icons in shared/networking/diego pipelines

### DIFF
--- a/cf-networking-release/pipelines/cf-networking-release.yml
+++ b/cf-networking-release/pipelines/cf-networking-release.yml
@@ -55,14 +55,14 @@ resource_types:
 resources:
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: cf-networking-repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch:  "develop"
     uri: git@github.com:cloudfoundry/cf-networking-release.git
@@ -70,7 +70,7 @@ resources:
 
 - name: silk-repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch:  "develop"
     uri: git@github.com:cloudfoundry/silk-release.git
@@ -78,7 +78,7 @@ resources:
 
 - name: cf-networking-release-branch
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release
     uri: git@github.com:cloudfoundry/cf-networking-release.git
@@ -86,7 +86,7 @@ resources:
 
 - name: silk-release-branch
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release
     uri: git@github.com:cloudfoundry/silk-release.git
@@ -94,7 +94,7 @@ resources:
 
 - name: cf-networking-develop-branch-mergeback
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/cf-networking-release.git
@@ -102,7 +102,7 @@ resources:
 
 - name: silk-develop-branch-mergeback
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/silk-release.git
@@ -110,12 +110,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: silk-readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -126,6 +128,7 @@ resources:
 
 - name: cf-networking-readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -136,28 +139,28 @@ resources:
 
 - name: cf-deployment
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment.git
 
 - name: cf-deployment-concourse-tasks
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 - name: cf-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release-candidate
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
 
 - name: healthchecker-release
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     uri: git@github.com:cloudfoundry/healthchecker-release.git
     private_key: ((github-tas-runtime-bot/private-key))
@@ -173,6 +176,7 @@ resources:
 
 - name: env
   type: shepherd
+  icon: sheep
   source:
     url: https://v2.shepherd.run
     service-account-key: ((shepherd-service-account-key))
@@ -184,37 +188,42 @@ resources:
     compatibility-mode: environments-app
 
 - name: cf-networking-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: cf-networking-release
     owner: cloudfoundry
-  type: github-release
 
 - name: silk-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: silk-release
     owner: cloudfoundry
-  type: github-release
 
 - name: cf-networking-draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: cf-networking-release
     owner: cloudfoundry
-  type: github-release
 
 - name: silk-draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: silk-release
     owner: cloudfoundry
-  type: github-release
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -223,6 +232,7 @@ resources:
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -230,15 +240,17 @@ resources:
     json_key: ((gcp-tas-runtime-service-account/config-json))
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: cf-networking-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     tag: 'latest'

--- a/diego-release/pipelines/diego-docker-images.yml
+++ b/diego-release/pipelines/diego-docker-images.yml
@@ -129,8 +129,9 @@ jobs:
 resources:
 - name: diego-inigo-ci-rootfs-dockerfile
   type: git
+  icon: source-branch
   source:
-    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
     branch: main
     private_key: ((github-tas-runtime-bot/private-key))
     paths:
@@ -138,6 +139,7 @@ resources:
 
 - name: oras-cli
   type: github-release
+  icon: github
   check_every: '24h'
   source:
     access_token: ((github-tas-runtime-bot/access-token))
@@ -146,6 +148,7 @@ resources:
 
 - name: docker-buildx
   type: github-release
+  icon: github
   check_every: '24h'
   source:
     access_token: ((github-tas-runtime-bot/access-token))
@@ -154,8 +157,9 @@ resources:
 
 - name: diego-docker-app-dockerfile
   type: git
+  icon: source-branch
   source:
-    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
     branch: main
     private_key: ((github-tas-runtime-bot/private-key))
     paths:
@@ -164,13 +168,15 @@ resources:
 
 - name: grace
   type: git
+  icon: source-branch
   source:
-    uri: https://github.com/cloudfoundry/grace.git
+    uri: git@github.com:cloudfoundry/grace.git
     branch: main
     private_key: ((github-tas-runtime-bot/private-key))
 
 - name: diego-docker-app
   type: docker-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
@@ -178,6 +184,7 @@ resources:
 
 - name: aws-ecr-docker-app
   type: docker-image
+  icon: docker
   source:
     aws_access_key_id: ((aws-ecr-diego-docker-app/access-key-id))
     aws_secret_access_key: ((aws-ecr-diego-docker-app/secret-access-key))
@@ -185,6 +192,7 @@ resources:
 
 - name: diego-inigo-ci-rootfs
   type: docker-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
@@ -192,6 +200,7 @@ resources:
 
 - name: cloudfoundry-grace-docker
   type: docker-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
@@ -199,6 +208,7 @@ resources:
 
 - name: image
   type: registry-image
+  icon: docker
   source:
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
@@ -206,6 +216,7 @@ resources:
 
 - name: cloudfoundry-grace-gcs
   type: google-cloud-storage
+  icon: bitbucket
   source:
     bucket: grace-assets
     regexp: grace-*.tgz
@@ -213,6 +224,7 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
@@ -220,14 +232,17 @@ resources:
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
-    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
+    private_key: ((github-tas-runtime-bot/private-key))
     paths:
     - go-version.json
 
 - name: http-golang-download
   type: command-runner
+  icon: link-variant
   source:
     version_key: "latest-golang"
     check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"

--- a/diego-release/pipelines/diego-release.yml
+++ b/diego-release/pipelines/diego-release.yml
@@ -62,14 +62,14 @@ resource_types:
 resources:
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/diego-release.git
@@ -77,6 +77,7 @@ resources:
 
 - name: release-branch 
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/diego-release.git
     branch: release
@@ -84,6 +85,7 @@ resources:
 
 - name: develop-branch-mergeback
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/diego-release.git
     branch: develop
@@ -91,6 +93,7 @@ resources:
 
 - name: diego-release-envoy-bump
   type: git
+  icon: source-branch
   source:
     branch: bump-envoy
     private_key: ((github-tas-runtime-bot/private-key))
@@ -98,12 +101,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -111,6 +116,7 @@ resources:
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -121,7 +127,7 @@ resources:
 #@ for repo in data.values.internal_repos:
 - name: #@ "{}-repo".format(repo.name)
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: #@ "git@github.com:cloudfoundry/{}.git".format(repo.name)
@@ -130,48 +136,49 @@ resources:
 
 - name: cf-deployment
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment.git
 
 - name: cf-deployment-concourse-tasks
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 - name: cf-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release-candidate
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
 
 - name: garden-runc-release
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: https://github.com/cloudfoundry/garden-runc-release.git
 
 - name: winc-release
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: https://github.com/cloudfoundry/winc-release.git
 
 - name: envoy-nginx-release
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: https://github.com/cloudfoundry/envoy-nginx-release.git
 
 - name: envoy-release
   type: github-release
+  icon: github
   check_every: '5m'
   source:
     access_token: ((github-tas-runtime-bot/access-token))
@@ -181,7 +188,7 @@ resources:
 
 - name: routing-release
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     branch: develop
     uri: https://github.com/cloudfoundry/routing-release.git
@@ -196,6 +203,7 @@ resources:
 
 - name: env
   type: shepherd
+  icon: sheep
   source:
     url: https://v2.shepherd.run
     service-account-key: ((shepherd-service-account-key))
@@ -207,22 +215,25 @@ resources:
     compatibility-mode: environments-app
 
 - name: github-release
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: diego-release
     owner: cloudfoundry
-  type: github-release
 
 - name: draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: diego-release
     owner: cloudfoundry
-  type: github-release
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -230,15 +241,17 @@ resources:
     json_key: ((gcp-tas-runtime-service-account/config-json))
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: diego-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     tag: 'latest'
@@ -247,6 +260,7 @@ resources:
 
 - name: diego-inigo-ci-rootfs
   type: docker-image
+  icon: docker
   source:
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/diego-inigo-ci-rootfs
     tag: latest
@@ -255,18 +269,21 @@ resources:
 
 - name: jq
   type: github-release
+  icon: github
   source:
     owner: jqlang
     repository: jq
 
 - name: tar
   type: s3
+  icon: bitbucket
   source:
     bucket: bosh-windows-dependencies
     regexp: tar-(.*).exe
 
 - name: winpty
   type: github-release
+  icon: github
   source:
     owner: rprichard
     repository: winpty

--- a/examples/pipeline/example.yml
+++ b/examples/pipeline/example.yml
@@ -34,34 +34,25 @@ groups:
 
 
 #! Define-ResourceGroups
-#! toolsmiths
 resource_types:
-- name: toolsmiths-envs
-  type: docker-image
+- name: shepherd
+  type: registry-image
   source:
-    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cftoolsmiths/toolsmiths-envs-resource
-    username: _json_key
-    password: ((gcp-tas-runtime-service-account/config-json))
-#! shepherd
-#! resource_types:
-#! - name: shepherd
-#!   type: registry-image
-#!   source:
-#!     repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
-#!     tag: v1  #! This may be bumped in the future
+    repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
+    tag: v1  #! This may be bumped in the future
 
 #! Define-Resources
 resources:
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:<REPLACE_ME>
@@ -69,6 +60,7 @@ resources:
 
 - name: release-branch 
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/<REPLACE_ME>.git
     branch: release
@@ -76,6 +68,7 @@ resources:
 
 - name: develop-branch-mergeback
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/<REPLACE_ME>.git
     branch: develop
@@ -83,33 +76,35 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: cf-deployment
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment.git
 
 - name: cf-deployment-concourse-tasks
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 - name: cf-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release-candidate
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -122,44 +117,40 @@ resources:
   source:
     interval: '24h'  #! 1 day
 
-#! Toolsmith pool
+#! Shepherd pool
 - name: env
-  type: toolsmiths-envs
+  type: shepherd
+  icon: sheep
   source:
-    api_token: ((toolsmiths-tas-journey-runtime-ecosystem-api-token))
-    pool_name: cf-deployment
-    hostname: environments.toolsmiths.cf-app.com
-
-#! shepherd
-#!- name: env
-#!  type: shepherd
-#!  source:
-#!    url: https://v2.shepherd.run
-#!    service-account-key: ((shepherd-service-account-key))
-#!    lease:
-#!      namespace: tas-runtime
-#!      pool:
-#!        namespace: official
-#!        name: cfd
-#!    compatibility-mode: environments-app
+    url: https://v2.shepherd.run
+    service-account-key: ((shepherd-service-account-key))
+    lease:
+      namespace: tas-runtime
+      pool:
+        namespace: official
+        name: cfd
+    compatibility-mode: environments-app
 
 - name: github-release
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: <REPLACE_ME>
     owner: cloudfoundry
-  type: github-release
 
 - name: draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: <REPLACE_ME>
     owner: cloudfoundry
-  type: github-release
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -167,15 +158,17 @@ resources:
     json_key: ((gcp-tas-runtime-service-account/config-json))
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: <REPLACE_ME>-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
@@ -313,21 +306,13 @@ jobs:
     - put: env-lock
       params:
        acquire: true
-  - put: env #!Claim env after env-lock is acquired
+  - put: env
+    timeout: 6h
     params:
-      action: claim
-  #! shepherd
-  #! - put: env
-  #!   params:
-  #!     action: create
-  #!     duration: 176h
-  #!     resource: env
-  #!  timeout: 6h
-  - task: renew-env #! Only applicable for toolsmiths
-    image: image
-    file: ci/shared/tasks/renew-toolsmiths/linux.yml
-    params:
-      TOOLSMITHS_API_TOKEN: ((toolsmiths-tas-journey-runtime-ecosystem-api-token))
+      action: create
+      duration: 176h
+      resource: env
+      description: 'example-release pipeline CHANGEME'
 
 - name: prepare-env
   serial: true
@@ -580,13 +565,8 @@ jobs:
   - get: env-lock
   - put: env
     params:
-      action: unclaim
-      env_file: env/metadata
-  #! shepherd
-  #! - put: env
-  #!   params:
-  #!     action: release
-  #!     resource: env
+      action: release
+      resource: env
   - params:
       release: env-lock #! path to the resource in the above get
     put: env-lock
@@ -600,13 +580,8 @@ jobs:
         passed: [claim-env]
       - put: env
         params:
-          action: unclaim
-          env_file: env/metadata
-      #!shepherd
-      #! - put: env
-      #!   params:
-      #!     action: release
-      #!     resource: env
+          action: release
+          resource: env
   ensure:
     put: env-lock
     params:

--- a/healthchecker-release/pipelines/healthchecker-release.yml
+++ b/healthchecker-release/pipelines/healthchecker-release.yml
@@ -44,14 +44,14 @@ resource_types:
 resources:
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/healthchecker-release
@@ -59,6 +59,7 @@ resources:
 
 - name: release-branch 
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/healthchecker-release.git
     branch: release
@@ -66,6 +67,7 @@ resources:
 
 - name: develop-branch-mergeback
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/healthchecker-release.git
     branch: develop
@@ -73,12 +75,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: repo-readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -89,6 +93,7 @@ resources:
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -103,6 +108,7 @@ resources:
 
 - name: env
   type: shepherd
+  icon: sheep
   source:
     url: https://v2.shepherd.run
     service-account-key: ((shepherd-service-account-key))
@@ -114,22 +120,25 @@ resources:
     compatibility-mode: environments-app
 
 - name: github-release
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: healthchecker-release
     owner: cloudfoundry
-  type: github-release
 
 - name: draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: healthchecker-release
     owner: cloudfoundry
-  type: github-release
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -138,6 +147,7 @@ resources:
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -145,15 +155,17 @@ resources:
     json_key: ((gcp-tas-runtime-service-account/config-json))
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: healthchecker-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key

--- a/nats-release/pipelines/nats-release.yml
+++ b/nats-release/pipelines/nats-release.yml
@@ -47,14 +47,14 @@ resource_types:
 resources:
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/nats-release
@@ -62,6 +62,7 @@ resources:
 
 - name: release-branch 
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/nats-release.git
     branch: release
@@ -69,6 +70,7 @@ resources:
 
 - name: develop-branch-mergeback
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/nats-release.git
     branch: develop
@@ -76,12 +78,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: repo-readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -92,6 +96,7 @@ resources:
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -99,21 +104,21 @@ resources:
 
 - name: cf-deployment
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment.git
 
 - name: cf-deployment-concourse-tasks
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 - name: cf-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release-candidate
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
@@ -128,6 +133,7 @@ resources:
 #! shephard
 - name: env
   type: shepherd
+  icon: sheep
   source:
     url: https://v2.shepherd.run
     service-account-key: ((shepherd-service-account-key))
@@ -139,22 +145,25 @@ resources:
     compatibility-mode: environments-app
 
 - name: github-release
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: nats-release
     owner: cloudfoundry
-  type: github-release
 
 - name: draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: nats-release
     owner: cloudfoundry
-  type: github-release
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -163,6 +172,7 @@ resources:
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -170,15 +180,17 @@ resources:
     json_key: ((gcp-tas-runtime-service-account/config-json))
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: nats-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key

--- a/routing-release/pipelines/routing-release.yml
+++ b/routing-release/pipelines/routing-release.yml
@@ -55,20 +55,21 @@ resources:
 #! REPOS
 - name: cipher-test-release
   type: git
+  icon: source-branch
   source:
     branch: master
     uri: https://github.com/cf-routing/cipher-test-release
 
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git
 
 - name: repo
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: develop
     uri: git@github.com:cloudfoundry/routing-release.git
@@ -76,6 +77,7 @@ resources:
 
 - name: release-branch 
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/routing-release.git
     branch: release
@@ -83,6 +85,7 @@ resources:
 
 - name: develop-branch-mergeback
   type: git
+  icon: source-branch
   source:
     uri: git@github.com:cloudfoundry/routing-release.git
     branch: develop
@@ -90,14 +93,15 @@ resources:
 
 - name: cf-cli-release
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
+    tag_filter: v*
     uri: https://github.com/bosh-packages/cf-cli-release.git
     branch: main
 
 - name: healthchecker-release
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     uri: git@github.com:cloudfoundry/healthchecker-release.git
     private_key: ((github-tas-runtime-bot/private-key))
@@ -106,14 +110,14 @@ resources:
 
 - name: disaster-recovery-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/disaster-recovery-acceptance-tests.git
 
 - name: bbr-binary-release
   type: github-release
-  icon: github-face
+  icon: github
   check_every: '5m'
   source:
     user: cloudfoundry-incubator
@@ -122,12 +126,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -135,6 +141,7 @@ resources:
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -144,6 +151,7 @@ resources:
 
 - name: readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -155,7 +163,7 @@ resources:
 #@ for repo in data.values.internal_repos:
 - name: #@ "{}-repo".format(repo.name)
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: #@ "git@github.com:cloudfoundry/{}.git".format(repo.name)
@@ -165,14 +173,14 @@ resources:
 #! CF Deployment
 - name: cf-deployment
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment.git
 
 - name: cf-smoke-tests-release
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-smoke-tests-release.git
@@ -180,14 +188,14 @@ resources:
 #! Concourse Tasks
 - name: cf-deployment-concourse-tasks
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/cf-deployment-concourse-tasks.git
 
 - name: cf-acceptance-tests
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: release-candidate
     uri: https://github.com/cloudfoundry/cf-acceptance-tests
@@ -195,6 +203,7 @@ resources:
 #! STEMCELLS
 - name: gcp-stemcell-bionic
   type: bosh-io-stemcell
+  icon: tag-outline
   source:
     name: bosh-google-kvm-ubuntu-bionic-go_agent
 
@@ -208,6 +217,7 @@ resources:
 #! Deployment Environment pool
 - name: env
   type: shepherd
+  icon: sheep
   source:
     url: https://v2.shepherd.run
     service-account-key: ((shepherd-service-account-key))
@@ -219,22 +229,25 @@ resources:
     compatibility-mode: environments-app
 
 - name: github-release
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     repository: routing-release
     owner: cloudfoundry
-  type: github-release
 
 - name: draft-github-release 
+  type: github-release
+  icon: github
   source:
     access_token: ((github-tas-runtime-bot/access-token))
     drafts: true
     repository: routing-release
     owner: cloudfoundry
-  type: github-release
 
 - name: version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-release-versions
@@ -243,6 +256,7 @@ resources:
 
 - name: routing-api-cli-github-release
   type: github-release
+  icon: github
   check_every: '5m'
   source:
     user: cloudfoundry
@@ -251,6 +265,7 @@ resources:
 
 - name: routing-api-cli-version
   type: semver
+  icon: counter
   source:
     json_key: ((gcp-tas-runtime-service-account/config-json))
     bucket: ci-release-versions
@@ -259,15 +274,17 @@ resources:
     driver: gcs
 
 - name: env-lock
+  type: pool
+  icon: cloud-lock
   source:
     branch: main
     pool: routing-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-  type: pool
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
@@ -276,12 +293,14 @@ resources:
 
 - name: jq
   type: github-release
+  icon: github
   source:
     owner: jqlang
     repository: jq
 
 - name: haproxy
   type: git
+  icon: tag-outline
   source:
     uri: https://git.haproxy.org/git/haproxy-2.8.git
     tag_filter: v*

--- a/shared/pipelines/linters.yml
+++ b/shared/pipelines/linters.yml
@@ -5,11 +5,13 @@ groups:
 resources:
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 - name: tas-runtime-build
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key

--- a/shared/pipelines/periodics.yml
+++ b/shared/pipelines/periodics.yml
@@ -6,11 +6,13 @@ groups:
 resources:
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key

--- a/shared/pipelines/shared-docker-images.yml
+++ b/shared/pipelines/shared-docker-images.yml
@@ -9,12 +9,14 @@ resource_types:
 resources:
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
     private_key: ((github-tas-runtime-bot/private-key))
 - name: go-version
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -22,6 +24,7 @@ resources:
     - go-version.json
 - name: build-dockerfile
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
@@ -30,6 +33,7 @@ resources:
     - shared/dockerfiles/tas-runtime-build/*
 - name: build-image
   type: registry-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
@@ -37,6 +41,7 @@ resources:
 
 - name: build-image-version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-image-versions
@@ -45,6 +50,7 @@ resources:
     initial_version: 0.0.147
 - name: ruby-installer-git
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:postmodern/ruby-install.git
@@ -52,12 +58,14 @@ resources:
     fetch_tags: true
 - name: ruby-git
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:ruby/ruby.git
     tag_filter: v3_2_2
 - name: postgres-dockerfile
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
@@ -66,12 +74,14 @@ resources:
     - shared/dockerfiles/tas-runtime-postgres/*
 - name: postgres-image
   type: registry-image 
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
     repository: cloudfoundry/tas-runtime-postgres
 - name: postgres-image-version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-image-versions
@@ -80,12 +90,14 @@ resources:
     initial_version: 0.0.1
 - name: postgres-docker-repo
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:docker-library/postgres.git
     branch: master
 - name: mysql-8.0-dockerfile
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
@@ -94,12 +106,14 @@ resources:
     - shared/dockerfiles/tas-runtime-mysql-8.0/*
 - name: mysql-8.0-image
   type: registry-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
     repository: cloudfoundry/tas-runtime-mysql-8.0
 - name: mysql-8.0-image-version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-image-versions
@@ -108,12 +122,14 @@ resources:
     initial_version: 0.0.1
 - name: mysql-docker-repo
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:docker-library/mysql.git
     branch: master
 - name: mysql-5.7-dockerfile
   type: git
+  icon: source-branch
   source:
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
@@ -122,12 +138,14 @@ resources:
     - shared/dockerfiles/tas-runtime-mysql-5.7/*
 - name: mysql-5.7-image
   type: registry-image 
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
     repository: cloudfoundry/tas-runtime-mysql-5.7
 - name: mysql-5.7-image-version
   type: semver
+  icon: counter
   source:
     driver: gcs
     bucket: ci-image-versions
@@ -136,6 +154,7 @@ resources:
     initial_version: 0.0.1
 - name: official-mysql-5.7-image
   type: docker-image
+  icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
@@ -143,6 +162,7 @@ resources:
     tag: 5.7-debian
 - name: http-golang-download
   type: command-runner
+  icon: link-variant
   source:
     version_key: "latest-golang"
     check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"

--- a/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
+++ b/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
@@ -14,7 +14,7 @@ resources:
 #@ for package in data.values.internal_repos:
 - name: #@ package.name
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main 
     uri: #@ "git@github.com:{}".format(package.repo)
@@ -23,12 +23,14 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -37,6 +39,7 @@ resources:
 
 - name: readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -47,6 +50,7 @@ resources:
 
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
@@ -55,7 +59,7 @@ resources:
 
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git

--- a/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
+++ b/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
@@ -13,7 +13,7 @@ resources:
 #@ for package in data.values.internal_repos:
 - name: #@ package.name
   type: git
-  icon: github-box
+  icon: source-branch
   source:
     branch: main 
     uri: #@ "git@github.com:{}".format(package.repo)
@@ -22,19 +22,23 @@ resources:
 
 - name: ci
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: shared-templates
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
     paths: 
       - shared/github
+
 - name: readme
   type: git
+  icon: source-branch
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
@@ -43,9 +47,9 @@ resources:
       - wg-arp-networking-modules/*.md
       - wg-arp-networking-modules/readme/*.md
 
-
 - name: image
   type: docker-image                             
+  icon: docker
   source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
@@ -54,7 +58,7 @@ resources:
 
 - name: golang-release-latest
   type: git
-  icon: github-box
+  icon: tag-outline
   source:
     tag_filter: v*
     uri: https://github.com/bosh-packages/golang-release.git


### PR DESCRIPTION
Also updated the icons in the example pipeline.yml

Scheme:
Type → Icon Type
- git → source-branch
- git with tag_filter → tag-outline
- github-release → github
- gcs resource → bitbucket
- s3 resource → bitbucket
- slack-notification → slack
- semver → counter
- bosh-io-release → tag-outline
- bosh-io-stemcell → tag-outline
- docker-image → docker
- registry-image → docker
- pool → cloud-lock
- github-pr → source-pull
- command-runner → link-variant