### PR TITLE
Revert gchat notify

### DIFF
--- a/cf-networking-release/pipelines/cf-networking-release.yml
+++ b/cf-networking-release/pipelines/cf-networking-release.yml
@@ -50,11 +50,6 @@ resource_types:
   source:
     repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
     tag: v1  #! This may be bumped in the future
-- name: cogito
-  type: registry-image
-  check_every: 168h
-  source:
-    repository: pix4d/cogito
 
 #! Define-Resources
 resources:
@@ -126,7 +121,7 @@ resources:
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
-    paths:
+    paths: 
       - shared/*.md
       - silk-release/*.md
       - silk-release/readme/*.md
@@ -137,7 +132,7 @@ resources:
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
-    paths:
+    paths: 
       - shared/*.md
       - cf-networking-release/*.md
       - cf-networking-release/readme/*.md
@@ -192,7 +187,7 @@ resources:
         name: cfd
     compatibility-mode: environments-app
 
-- name: cf-networking-github-release
+- name: cf-networking-github-release 
   type: github-release
   icon: github
   source:
@@ -200,7 +195,7 @@ resources:
     repository: cf-networking-release
     owner: cloudfoundry
 
-- name: silk-github-release
+- name: silk-github-release 
   type: github-release
   icon: github
   source:
@@ -208,7 +203,7 @@ resources:
     repository: silk-release
     owner: cloudfoundry
 
-- name: cf-networking-draft-github-release
+- name: cf-networking-draft-github-release 
   type: github-release
   icon: github
   source:
@@ -217,7 +212,7 @@ resources:
     repository: cf-networking-release
     owner: cloudfoundry
 
-- name: silk-draft-github-release
+- name: silk-draft-github-release 
   type: github-release
   icon: github
   source:
@@ -232,7 +227,7 @@ resources:
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
-    paths:
+    paths: 
       - shared/github
 
 - name: version
@@ -249,43 +244,24 @@ resources:
   icon: cloud-lock
   source:
     branch: main
-    pool: cf-networking-release-env-lock
+    pool: cf-networking-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
 
 - name: image
-  type: docker-image
+  type: docker-image                             
   icon: docker
-  source:
+  source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     tag: 'latest'
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
 
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
 
 #! Define-Jobs
 jobs:
 - name: bump-dependencies-go-mod
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -335,7 +311,6 @@ jobs:
           repository: bumped-silk
 
 - name: bump-package-golang
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -398,7 +373,6 @@ jobs:
           repository: silk-vendored-repo
 
 - name: bump-healthchecker-in-networking-release
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -422,7 +396,6 @@ jobs:
       repository: vendored-repo
 
 - name: bump-healthchecker-in-silk-release
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -447,7 +420,6 @@ jobs:
 
 - name: sync-dot-github-dir-in-networking-release
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -469,7 +441,6 @@ jobs:
 
 - name: sync-dot-github-dir-in-silk-release
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -491,7 +462,6 @@ jobs:
 
 - name: sync-readme-in-networking-release
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -515,7 +485,6 @@ jobs:
 
 - name: sync-readme-in-silk-release
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -537,9 +506,9 @@ jobs:
        rebase: true
        repository: synced-repo
 
+
 - name: template-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -566,7 +535,6 @@ jobs:
 
 - name: unit-and-integration-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -633,11 +601,10 @@ jobs:
 
 - name: lint-repo
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
-    - get: silk-repo
+    - get: silk-repo 
       trigger: true
     - get: cf-networking-repo
       trigger: true
@@ -655,7 +622,6 @@ jobs:
 
 - name: claim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -691,7 +657,6 @@ jobs:
 
 - name: prepare-env
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -799,7 +764,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -835,7 +799,6 @@ jobs:
 - name: run-service-discovery-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -866,7 +829,7 @@ jobs:
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
     params:
       CONFIGS: service-discovery-acceptance-tests
-      WITH_ISOSEG: false
+      WITH_ISOSEG: false 
       WITH_DYNAMIC_ASG: true
   - task: service-discovery-acceptance-tests
     file: ci/shared/tasks/run-bin-test/linux.yml
@@ -884,10 +847,10 @@ jobs:
       DIR: src/code.cloudfoundry.org/test/acceptance-sd
       FLAGS: "--procs=1" #!TODO: acceptance tests can't run in parallel, overwrite default ginkgo flag to run in serial
 
+
 - name: run-cf-networking-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -918,7 +881,7 @@ jobs:
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
     params:
       CONFIGS: cf-networking-acceptance-tests
-      WITH_ISOSEG: false
+      WITH_ISOSEG: false 
       WITH_DYNAMIC_ASG: true
   - task: cf-networking-acceptance-tests
     file: ci/shared/tasks/run-bin-test/linux.yml
@@ -938,7 +901,6 @@ jobs:
 
 - name: run-service-discovery-performance-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: cf-networking-repo
@@ -977,7 +939,6 @@ jobs:
 
 - name: export-release
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1004,7 +965,6 @@ jobs:
       repo: silk-repo
 
 - name: ship-what
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -1070,7 +1030,6 @@ jobs:
 
 - name: ship-it
   serial: true
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -1206,7 +1165,6 @@ jobs:
 
 - name: unclaim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - get: env
     passed: [ship-what]
@@ -1221,7 +1179,6 @@ jobs:
     put: env-lock
 
 - name: release-env-lock
-  <<: *gchat_notification
   plan:
   - get: env-lock
   ensure:
@@ -1232,7 +1189,6 @@ jobs:
 #! versioning
 - name: patch-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: patch}
@@ -1241,7 +1197,6 @@ jobs:
 
 - name: minor-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: minor}
@@ -1250,7 +1205,6 @@ jobs:
 
 - name: major-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: major}

--- a/cpu-entitlement-plugin/pipelines/cpu-entitlement-plugin.yml
+++ b/cpu-entitlement-plugin/pipelines/cpu-entitlement-plugin.yml
@@ -37,12 +37,6 @@ resource_types:
     repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
     tag: v1  #! This may be bumped in the future
 
-- name: cogito
-  type: registry-image
-  check_every: 168h
-  source:
-    repository: pix4d/cogito
-
 #! Define-Resources
 resources:
 - name: repo
@@ -61,7 +55,7 @@ resources:
     uri: git@github.com:cloudfoundry/test-log-emitter-release.git
     private_key: ((github-tas-runtime-bot/private-key))
 
-- name: release-branch
+- name: release-branch 
   type: git
   icon: source-branch
   source:
@@ -126,7 +120,7 @@ resources:
     repository: cpu-entitlement-plugin
     owner: cloudfoundry
 
-- name: draft-github-release
+- name: draft-github-release 
   type: github-release
   icon: github
   source:
@@ -149,50 +143,30 @@ resources:
   icon: cloud-lock
   source:
     branch: main
-    pool: cpu-entitlement-plugin-env-lock
+    pool: cpu-entitlement-plugin-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
 
 - name: image
-  type: docker-image
+  type: docker-image                             
   icon: docker
-  source:
+  source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     tag: 'latest'
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
 
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
-
 #! Define-Jobs
 jobs:
 - name: bump-dependencies-go-mod
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
       - get: ci
       - get: repo
       - get: image
-      - get: daily
+      - get: daily 
         trigger: true
   - task: cpu-entitlement-plugin-bump-dependencies-go-mod
     image: image
@@ -206,7 +180,6 @@ jobs:
 
 - name: unit-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -229,7 +202,6 @@ jobs:
 
 - name: claim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -257,7 +229,6 @@ jobs:
 
 - name: prepare-env
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -299,7 +270,6 @@ jobs:
 - name: run-integration-tests
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -340,7 +310,6 @@ jobs:
 - name: run-e2e-tests
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -387,7 +356,6 @@ jobs:
       image_tag: ((.:image_tag))
 
 - name: ship-what
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -435,7 +403,6 @@ jobs:
 
 - name: ship-it
   serial: true
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -515,7 +482,6 @@ jobs:
 
 - name: unclaim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - get: env
     passed: [ship-what]
@@ -530,7 +496,6 @@ jobs:
     put: env-lock
 
 - name: release-env-lock
-  <<: *gchat_notification
   plan:
   - get: env-lock
   ensure:
@@ -541,7 +506,6 @@ jobs:
 #! versioning
 - name: patch-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: patch}
@@ -550,7 +514,6 @@ jobs:
 
 - name: minor-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: minor}
@@ -559,7 +522,6 @@ jobs:
 
 - name: major-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: major}

--- a/diego-release/pipelines/diego-docker-images.yml
+++ b/diego-release/pipelines/diego-docker-images.yml
@@ -1,171 +1,8 @@
 ---
-resource_types:
-  - name: google-cloud-storage
-    type: docker-image
-    source:
-      repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/frodenas/gcs-resource
-      username: _json_key
-      password: ((gcp-tas-runtime-service-account/config-json))
-
-  - name: command-runner
-    type: docker-image
-    source:
-      repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundrydevelopers/command-runner-resource
-      tag: latest
-      username: _json_key
-      password: ((gcp-tas-runtime-service-account/config-json))
-
-  - name: cogito
-    type: registry-image
-    check_every: 168h
-    source:
-      repository: pix4d/cogito
-
-resources:
-  - name: diego-inigo-ci-rootfs-dockerfile
-    type: git
-    icon: source-branch
-    source:
-      uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
-      branch: main
-      private_key: ((github-tas-runtime-bot/private-key))
-      paths:
-        - diego-release/dockerfiles/diego-inigo-ci-rootfs/Dockerfile
-
-  - name: oras-cli
-    type: github-release
-    icon: github
-    check_every: '24h'
-    source:
-      access_token: ((github-tas-runtime-bot/access-token))
-      owner: oras-project
-      repository: oras
-
-  - name: docker-buildx
-    type: github-release
-    icon: github
-    check_every: '24h'
-    source:
-      access_token: ((github-tas-runtime-bot/access-token))
-      owner: docker
-      repository: buildx
-
-  - name: diego-docker-app-dockerfile
-    type: git
-    icon: source-branch
-    source:
-      uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
-      branch: main
-      private_key: ((github-tas-runtime-bot/private-key))
-      paths:
-        - diego-release/dockerfiles/diego-docker-app/Dockerfile
-        - diego-release/dockerfiles/diego-docker-app/dockerapp.go
-
-  - name: grace
-    type: git
-    icon: source-branch
-    source:
-      uri: git@github.com:cloudfoundry/grace.git
-      branch: main
-      private_key: ((github-tas-runtime-bot/private-key))
-
-  - name: diego-docker-app
-    type: docker-image
-    icon: docker
-    source:
-      username: ((dockerhub-tasruntime-username))
-      password: ((dockerhub-tasruntime-password))
-      repository: cloudfoundry/diego-docker-app
-
-  - name: aws-ecr-docker-app
-    type: docker-image
-    icon: docker
-    source:
-      aws_access_key_id: ((aws-ecr-diego-docker-app/access-key-id))
-      aws_secret_access_key: ((aws-ecr-diego-docker-app/secret-access-key))
-      repository: ((aws-ecr-diego-docker-app/ref))
-
-  - name: diego-inigo-ci-rootfs
-    type: docker-image
-    icon: docker
-    source:
-      username: ((dockerhub-tasruntime-username))
-      password: ((dockerhub-tasruntime-password))
-      repository: cloudfoundry/diego-inigo-ci-rootfs
-
-  - name: cloudfoundry-grace-docker
-    type: docker-image
-    icon: docker
-    source:
-      username: ((dockerhub-tasruntime-username))
-      password: ((dockerhub-tasruntime-password))
-      repository: cloudfoundry/grace
-
-  - name: image
-    type: registry-image
-    icon: docker
-    source:
-      repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
-      username: _json_key
-      password: ((gcp-tas-runtime-service-account/config-json))
-
-  - name: cloudfoundry-grace-gcs
-    type: google-cloud-storage
-    icon: bitbucket
-    source:
-      bucket: grace-assets
-      regexp: grace-*.tgz
-      json_key: ((gcp-tas-runtime-service-account/config-json))
-
-  - name: ci
-    type: git
-    icon: source-branch
-    source:
-      branch: main
-      uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
-      private_key: ((github-tas-runtime-bot/private-key))
-
-  - name: go-version
-    type: git
-    icon: source-branch
-    source:
-      branch: main
-      uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
-      private_key: ((github-tas-runtime-bot/private-key))
-      paths:
-        - go-version.json
-
-  - name: http-golang-download
-    type: command-runner
-    icon: link-variant
-    source:
-      version_key: "latest-golang"
-      check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
-      in_command:    "curl --silent --fail --output $1/golang.tgz https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
-
-  - name: chat-notify
-    type: cogito
-    check_every: never
-    source:
-      sinks:
-        - gchat
-      gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
-
 jobs:
+
 - name: diego-inigo-ci-rootfs
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -188,7 +25,6 @@ jobs:
 
 - name: diego-docker-app
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -216,7 +52,6 @@ jobs:
 
 - name: diego-oci-app
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -254,7 +89,6 @@ jobs:
 
 - name: grace
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: http-golang-download
@@ -291,3 +125,140 @@ jobs:
     params:
       file: released-binaries/grace-*.tgz
       predefined_acl: publicRead
+
+resources:
+- name: diego-inigo-ci-rootfs-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - diego-release/dockerfiles/diego-inigo-ci-rootfs/Dockerfile
+
+- name: oras-cli
+  type: github-release
+  icon: github
+  check_every: '24h'
+  source:
+    access_token: ((github-tas-runtime-bot/access-token))
+    owner: oras-project
+    repository: oras
+
+- name: docker-buildx
+  type: github-release
+  icon: github
+  check_every: '24h'
+  source:
+    access_token: ((github-tas-runtime-bot/access-token))
+    owner: docker
+    repository: buildx
+
+- name: diego-docker-app-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - diego-release/dockerfiles/diego-docker-app/Dockerfile
+    - diego-release/dockerfiles/diego-docker-app/dockerapp.go
+
+- name: grace
+  type: git
+  icon: source-branch
+  source:
+    uri: git@github.com:cloudfoundry/grace.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+
+- name: diego-docker-app
+  type: docker-image
+  icon: docker
+  source:
+    username: ((dockerhub-tasruntime-username))
+    password: ((dockerhub-tasruntime-password))
+    repository: cloudfoundry/diego-docker-app
+
+- name: aws-ecr-docker-app
+  type: docker-image
+  icon: docker
+  source:
+    aws_access_key_id: ((aws-ecr-diego-docker-app/access-key-id))
+    aws_secret_access_key: ((aws-ecr-diego-docker-app/secret-access-key))
+    repository: ((aws-ecr-diego-docker-app/ref))
+
+- name: diego-inigo-ci-rootfs
+  type: docker-image
+  icon: docker
+  source:
+    username: ((dockerhub-tasruntime-username))
+    password: ((dockerhub-tasruntime-password))
+    repository: cloudfoundry/diego-inigo-ci-rootfs
+
+- name: cloudfoundry-grace-docker
+  type: docker-image
+  icon: docker
+  source:
+    username: ((dockerhub-tasruntime-username))
+    password: ((dockerhub-tasruntime-password))
+    repository: cloudfoundry/grace
+
+- name: image
+  type: registry-image
+  icon: docker
+  source:
+    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+    username: _json_key
+    password: ((gcp-tas-runtime-service-account/config-json))
+
+- name: cloudfoundry-grace-gcs
+  type: google-cloud-storage
+  icon: bitbucket
+  source:
+    bucket: grace-assets
+    regexp: grace-*.tgz
+    json_key: ((gcp-tas-runtime-service-account/config-json))
+
+- name: ci
+  type: git
+  icon: source-branch
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
+    private_key: ((github-tas-runtime-bot/private-key))
+
+- name: go-version
+  type: git
+  icon: source-branch
+  source:
+    branch: main
+    uri: git@github.com:cloudfoundry/wg-app-platform-runtime-ci
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - go-version.json
+
+- name: http-golang-download
+  type: command-runner
+  icon: link-variant
+  source:
+    version_key: "latest-golang"
+    check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
+    in_command:    "curl --silent --fail --output $1/golang.tgz https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
+
+resource_types:
+- name: google-cloud-storage
+  type: docker-image
+  source:
+    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/frodenas/gcs-resource
+    username: _json_key
+    password: ((gcp-tas-runtime-service-account/config-json))
+- name: command-runner
+  type: docker-image
+  source:
+    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundrydevelopers/command-runner-resource
+    tag: latest
+    username: _json_key
+    password: ((gcp-tas-runtime-service-account/config-json))

--- a/diego-release/pipelines/diego-release.yml
+++ b/diego-release/pipelines/diego-release.yml
@@ -52,18 +52,11 @@ resource_types:
     tag: latest
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
-
 - name: shepherd
   type: registry-image
   source:
     repository: us-west2-docker.pkg.dev/shepherd-268822/shepherd2/concourse-resource
     tag: v1  #! This may be bumped in the future
-
-- name: cogito
-  type: registry-image
-  check_every: 168h
-  source:
-    repository: pix4d/cogito
 
 #! Define-Resources
 resources:
@@ -82,7 +75,7 @@ resources:
     uri: git@github.com:cloudfoundry/diego-release.git
     private_key: ((github-tas-runtime-bot/private-key))
 
-- name: release-branch
+- name: release-branch 
   type: git
   icon: source-branch
   source:
@@ -127,7 +120,7 @@ resources:
   source:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
-    paths:
+    paths: 
       - shared/github
       - diego-release/github
 
@@ -202,7 +195,7 @@ resources:
     tag_filter: v0.285.0
 
 #! TIMERS
-- name: daily
+- name: daily 
   type: time
   icon: clock
   source:
@@ -229,7 +222,7 @@ resources:
     repository: diego-release
     owner: cloudfoundry
 
-- name: draft-github-release
+- name: draft-github-release 
   type: github-release
   icon: github
   source:
@@ -252,14 +245,14 @@ resources:
   icon: cloud-lock
   source:
     branch: main
-    pool: diego-release-env-lock
+    pool: diego-release-env-lock 
     private_key: ((github-tas-runtime-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
 
 - name: image
-  type: docker-image
+  type: docker-image                             
   icon: docker
-  source:
+  source:                                        
     repository: cloudfoundry/tas-runtime-build
     tag: 'latest'
     username: ((dockerhub-tasruntime-username))
@@ -296,37 +289,17 @@ resources:
     repository: winpty
     order_by: time
 
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
-
 #! Define-Jobs
 jobs:
 - name: bump-dependencies-go-mod
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
       - get: ci
       - get: repo
       - get: image
-      - get: daily
+      - get: daily 
         trigger: true
   - task: diego-release-bump-dependencies-go-mod
     image: image
@@ -344,7 +317,6 @@ jobs:
 - name: bump-golang
   old_name: bump-package-golang
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -402,7 +374,6 @@ jobs:
 
 - name: bump-bosh-blobs
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -412,14 +383,14 @@ jobs:
       - get: jq
         params:
           globs:
-          - jq-linux-amd64
+          - jq-linux-amd64 
         trigger: true
       - get: tar
         trigger: true
       - get: winpty
         params:
           globs:
-          - winpty-*-msvc2015.zip
+          - winpty-*-msvc2015.zip 
         trigger: true
   - do:
     - task: bump-bosh-blob-jq
@@ -428,7 +399,7 @@ jobs:
       input_mapping:
         blob: jq
       params:
-        BOSH_BLOB_PATH: jq/jq-*-linux-amd64.tgz
+        BOSH_BLOB_PATH: jq/jq-*-linux-amd64.tgz 
         AWS_ACCESS_KEY_ID: ((aws-s3-diego-release-blobs/access-key-id))
         AWS_SECRET_ACCESS_KEY: ((aws-s3-diego-release-blobs/secret-access-key))
     - put: repo
@@ -466,7 +437,6 @@ jobs:
 
 - name: bump-dependencies-envoy
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -493,7 +463,6 @@ jobs:
 
 - name: create-envoy-pr
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -514,7 +483,6 @@ jobs:
 
 - name: sync-dot-github-dir
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:
@@ -551,9 +519,9 @@ jobs:
        repository: synced-repo
 #@ end
 
+
 - name: template-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -567,7 +535,6 @@ jobs:
 
 - name: unit-and-integration-tests
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -661,7 +628,7 @@ jobs:
     - task: #@ "{}-windows".format(package.name)
       file: ci/shared/tasks/run-bin-test/windows.yml
       tags: [ diego-windows ]
-      privileged: true #! for windows test
+      privileged: true #! for windows test 
       attempts: 3
       input_mapping:
         built-binaries: windows-built-binaries
@@ -672,7 +639,6 @@ jobs:
 #@ for db in data.values.db_flavors:
 - name: #@ "inigo-{}-linux".format(db.value)
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -777,7 +743,6 @@ jobs:
 #@ end
 - name: inigo-mysql-windows
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -885,10 +850,8 @@ jobs:
           --skip-package volman,executor,certauthority
         FUNCTIONS: |
           ci/winc-release/helpers/configure-binaries.ps1
-
 - name: lint-repo
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -903,7 +866,6 @@ jobs:
 
 - name: claim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -936,7 +898,6 @@ jobs:
 - name: prepare-env
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1047,7 +1008,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1079,7 +1039,6 @@ jobs:
 - name: run-wats
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1113,7 +1072,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1132,7 +1090,6 @@ jobs:
 - name: run-vizzini
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1153,7 +1110,6 @@ jobs:
 - name: run-bosh-restart
   serial: true
   serial_groups: [acceptance]
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: ci
@@ -1180,7 +1136,6 @@ jobs:
       config: built-acceptance-test-configs
 
 - name: ship-what
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -1222,7 +1177,6 @@ jobs:
 
 - name: ship-it
   serial: true
-  <<: *gchat_notification
   plan:
     - in_parallel:
         steps:
@@ -1297,7 +1251,6 @@ jobs:
 
 - name: unclaim-env
   serial: true
-  <<: *gchat_notification
   plan:
   - get: env
     passed: [ship-what]
@@ -1312,7 +1265,6 @@ jobs:
     put: env-lock
 
 - name: release-env-lock
-  <<: *gchat_notification
   plan:
   - get: env-lock
   ensure:
@@ -1323,7 +1275,6 @@ jobs:
 #! versioning
 - name: patch-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: patch}
@@ -1332,7 +1283,6 @@ jobs:
 
 - name: minor-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: minor}
@@ -1341,7 +1291,6 @@ jobs:
 
 - name: major-bump
   serial_groups: [version]
-  <<: *gchat_notification
   plan:
   - get: version
     params: {bump: major}

--- a/shared/pipelines/linters.yml
+++ b/shared/pipelines/linters.yml
@@ -1,15 +1,7 @@
-resource_types:
-- name: cogito
-  type: registry-image
-  check_every: 168h
-  source:
-    repository: pix4d/cogito
-
 groups:
 - name: main
   jobs:
   - lint-ci
-
 resources:
 - name: ci
   type: git
@@ -18,36 +10,17 @@ resources:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 - name: tas-runtime-build
-  type: docker-image
+  type: docker-image                             
   icon: docker
-  source:
+  source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
     tag: 'latest'
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
 
 jobs:
 - name: lint-ci
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:

--- a/shared/pipelines/periodics.yml
+++ b/shared/pipelines/periodics.yml
@@ -1,10 +1,3 @@
-resource_types:
-  - name: cogito
-    type: registry-image
-    check_every: 168h
-    source:
-      repository: pix4d/cogito
-
 groups:
 - name: main
   jobs:
@@ -18,9 +11,9 @@ resources:
     branch: main
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 - name: image
-  type: docker-image
+  type: docker-image                             
   icon: docker
-  source:
+  source:                                        
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
@@ -32,29 +25,10 @@ resources:
     start: 11:00 PM
     stop: 11:30 PM
     location: America/New_York
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
 
 jobs:
 - name: go-clean-cache-windows
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
       steps:

--- a/shared/pipelines/shared-docker-images.yml
+++ b/shared/pipelines/shared-docker-images.yml
@@ -6,12 +6,6 @@ resource_types:
     username: _json_key
     password: ((gcp-tas-runtime-service-account/config-json))
     tag: latest
-- name: cogito
-  type: registry-image
-  check_every: 168h
-  source:
-    repository: pix4d/cogito
-
 resources:
 - name: ci
   type: git
@@ -44,6 +38,7 @@ resources:
     username: ((dockerhub-tasruntime-username))
     password: ((dockerhub-tasruntime-password))
     repository: cloudfoundry/tas-runtime-build
+
 - name: build-image-version
   type: semver
   icon: counter
@@ -78,7 +73,7 @@ resources:
     paths:
     - shared/dockerfiles/tas-runtime-postgres/*
 - name: postgres-image
-  type: registry-image
+  type: registry-image 
   icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
@@ -142,7 +137,7 @@ resources:
     paths:
     - shared/dockerfiles/tas-runtime-mysql-5.7/*
 - name: mysql-5.7-image
-  type: registry-image
+  type: registry-image 
   icon: docker
   source:
     username: ((dockerhub-tasruntime-username))
@@ -172,29 +167,9 @@ resources:
     version_key: "latest-golang"
     check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
     in_command:    "curl --silent --fail --output $1/golang.tgz https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
-- name: chat-notify
-  type: cogito
-  check_every: never
-  source:
-    sinks:
-      - gchat
-    gchat_webhook: ((concourse-google-chat-webhook))
-
-meta:
-  gchat_notification: &gchat_notification
-    on_failure:
-      put: chat-notify
-      params:
-        state: failure
-    on_error:
-      put: chat-notify
-      params:
-        state: error
-
 jobs:
 - name: build-build-image
   serial: true
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: http-golang-download
@@ -282,7 +257,6 @@ jobs:
     params:
       file: build-image-version/version
 - name: build-postgres-image
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: postgres-dockerfile
@@ -379,7 +353,6 @@ jobs:
     params:
       file: postgres-image-version/version
 - name: build-mysql-8.0-image
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: mysql-8.0-dockerfile
@@ -487,7 +460,6 @@ jobs:
     params:
       file: mysql-8.0-image-version/version
 - name: build-mysql-5.7-image
-  <<: *gchat_notification
   plan:
   - in_parallel:
     - get: mysql-5.7-dockerfile


### PR DESCRIPTION
The changes made either does not work with how the pipelines are currently set up or does not work consistently. So far, there are two issues I can think of from the error logs:
1. The resource only works with HTTPS hostnames, not SSH hostnames
2. `put` on a resource that's not used will error so generically using the notify resource is not possible.

I’m going to create pipelines that mimic how the current pipelines are to do further testing before modifying the current pipelines