### PR TITLE
Automatically ship diego modules

### DIFF
--- a/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
+++ b/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
@@ -4,7 +4,7 @@
 #! Define-Groups
 groups:
 - name: test
-  jobs: #@ helpers.packages_names_array(data.values.internal_repos) 
+  jobs: #@ helpers.packages_names_array(data.values.internal_repos,["", "ship-it-"])
 
 - name: periodics
   jobs: #@ helpers.packages_names_array(data.values.internal_repos,["bump-dependencies-","sync-dot-github-dir-","sync-readme-"])
@@ -19,7 +19,24 @@ resources:
     branch: main 
     uri: #@ "git@github.com:{}".format(package.repo)
     private_key: ((github-tas-runtime-bot/private-key))
-  #@ end
+
+- name: #@ "{}-github-release".format(package.name)
+  type: github-release
+  icon: github
+  source:
+    access_token: ((github-tas-runtime-bot/access-token))
+    repository: #@ package.name
+    owner: cloudfoundry
+
+- name: #@ "{}-version".format(package.name)
+  type: semver
+  icon: counter
+  source:
+    driver: gcs
+    bucket: ci-release-versions
+    key: #@ "diego-modules/{}/version".format(package.name)
+    json_key: ((gcp-tas-runtime-service-account/config-json))
+#@ end
 
 - name: ci
   type: git
@@ -227,4 +244,35 @@ jobs:
     params:
       rebase: true
       repository: bumped-repo
+#@ end
+
+#@ for package in data.values.internal_repos:
+- name: #@ "ship-it-{}".format(package.name)
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: #@ "{}-version".format(package.name)
+      - resource: #@ package.name
+        get: repo
+        passed:
+        - #@ package.name
+        trigger: true
+  - put: #@ package.name
+    params:
+      repository: repo
+      tag: #@ "{}-version/number".format(package.name)
+      tag_prefix: v
+  - put: #@ "{}-github-release".format(package.name)
+    params:
+      name: #@ "{}-version/number".format(package.name)
+      tag: #@ "{}-version/number".format(package.name)
+      tag_prefix: v
+  - get: next-version
+    resource: #@ "{}-version".format(package.name)
+    params: {bump: minor}
+  - put: next-version
+    resource: #@ "{}-version".format(package.name)
+    params: {file: next-version/number}
 #@ end


### PR DESCRIPTION
* when there are changes that pass units
* before this some of the modules had releases and/or tags
* they were not being updated manually which means no one was getting the changes
* others had no tags/releases, so other projects were referencing them by commit sha
* now all diego modules are handled the same and have gh releases