### PR TITLE
Remove IMAGE_ID from our scripts to always use the latest version of envoy

### DIFF
--- a/diego-release/tasks/create-envoy-blob/linux.yml
+++ b/diego-release/tasks/create-envoy-blob/linux.yml
@@ -14,4 +14,3 @@ run:
 params:
   GCP_KEY:
   IMAGE_NAME: envoyproxy/envoy-build-ubuntu
-  IMAGE_ID: 0a02a76af5951bf7f4c7029c0ea6d29d96c0f682

--- a/diego-release/tasks/create-envoy-blob/task.bash
+++ b/diego-release/tasks/create-envoy-blob/task.bash
@@ -90,7 +90,7 @@ git clone https://github.com/envoyproxy/envoy
 cd envoy
 git checkout ${ENVOY_TAG}
 sed -i '/\"envoy.transport_sockets.tcp_stats\":.*\"\\/\\/source\\/extensions\\/transport_sockets\\/tcp_stats:config\",/d' source/extensions/extensions_build_config.bzl
-IMAGE_NAME=${IMAGE_NAME} IMAGE_ID=${IMAGE_ID} ENVOY_DOCKER_OPTIONS='--network=host' BAZEL_BUILD_EXTRA_OPTIONS='--flaky_test_attempts=10' ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release'
+IMAGE_NAME=${IMAGE_NAME} ENVOY_DOCKER_OPTIONS='--network=host' BAZEL_BUILD_EXTRA_OPTIONS='--flaky_test_attempts=10' ./ci/run_envoy_docker.sh './ci/do_ci.sh bazel.release'
 "
 
 popd


### PR DESCRIPTION
Envoy will default it's image-id to the latest, this will remove the need to keep the image id up to date.