### PR TITLE
Bump Go to 1.23

### DIFF
--- a/go-version.json
+++ b/go-version.json
@@ -1,6 +1,21 @@
 {
-    "default": "1.22",
+    "default": "1.23",
      "releases": {
+        "cf-networking": "1.22",
+        "diego": "1.22",
+        "envoy-nginx": "1.22",
+        "garden-runc": "1.22",
+        "healthchecker": "1.22",
+        "mapfs": "1.22",
+        "nats": "1.22",
+        "nfs-volume": "1.22",
+        "routing": "1.22",
+        "silk": "1.22",
+        "smb-volume": "1.22",
+        "test-log-emitter": "1.22",
+        "winc": "1.22",
+        "windows2019fs": "1.22",
+        "windowsfs-online": "1.22",
         "windows-tools": "1.22"
     }
 }


### PR DESCRIPTION
This is the start of a larger initiative to bump all ARP repo's to Go 1.23