### PR TITLE
Ugrading to Go 1.23 for misc releases

### DIFF
--- a/go-version.json
+++ b/go-version.json
@@ -2,13 +2,9 @@
     "default": "1.23",
      "releases": {
         "diego": "1.22",
-        "envoy-nginx": "1.22",
         "garden-runc": "1.22",
         "healthchecker": "1.22",
-        "mapfs": "1.22",
-        "nats": "1.22",
         "nfs-volume": "1.22",
-        "routing": "1.22",
         "smb-volume": "1.22",
         "test-log-emitter": "1.22"
     }


### PR DESCRIPTION
Updating the following releases to use Go 1.23:
- Envoy-nginx-release
- mapfs-release
- nats-release
- routing-release