### PR TITLE
Remove .NET-related resources for build-test-push

### DIFF
--- a/windows2016fs/pipelines/windows2016fs.yml
+++ b/windows2016fs/pipelines/windows2016fs.yml
@@ -76,6 +76,13 @@ resources:
     version_key: "dotnet-installer"
     check_command: "echo https://go.microsoft.com/fwlink/?linkid=2088631"
     in_command:    "curl --location --silent --fail --output $1/dotnet-48-installer.exe https://go.microsoft.com/fwlink/?linkid=2088631"
+- name: dotnet-48-patch
+  type: command-runner
+  icon: link-variant
+  source:
+    version_key: "dotnet-48-patch"
+    check_command: "echo https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2024/07/windows10.0-kb5041974-x64-ndp48_e8660214346c8ac124e2f99aa21eef697fff307d.msu"
+    in_command:    "curl --location --silent --fail --output $1/dotnet-48-patch.msu https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2024/07/windows10.0-kb5041974-x64-ndp48_e8660214346c8ac124e2f99aa21eef697fff307d.msu"
 - name: rewrite-msi
   type: command-runner
   icon: link-variant
@@ -135,6 +142,7 @@ jobs:
     - get: vcredist-2010
     - get: vcredist-2010-x86
     - get: dotnet-48-installer
+    - get: dotnet-48-patch
     - get: rewrite-msi
     - get: version
       params: {bump: patch}
@@ -150,6 +158,7 @@ jobs:
       input-06: dotnet-48-installer
       input-07: rewrite-msi
       input-08: repo
+      input-09: dotnet-48-patch
     params:
       COPY_ACTIONS: |
         {input-01/Git-*-64-bit.exe,combined-assets}
@@ -160,6 +169,7 @@ jobs:
         {input-06/dotnet-48-installer.exe,combined-assets}
         {input-07/rewrite.msi,combined-assets}
         {input-08/2019/Dockerfile,combined-assets}
+        {input-09/dotnet-48-patch.msu,combined-assets}
   - task: build-test-push-windows2016fs
     file: ci/shared/tasks/run-bin-test/windows.yml
     input_mapping:

--- a/windows2016fs/pipelines/windows2016fs.yml
+++ b/windows2016fs/pipelines/windows2016fs.yml
@@ -69,20 +69,6 @@ resources:
     version_key: "2010-hardcoded-url"
     check_command: "echo https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe"
     in_command:    "curl --silent --fail --output $1/vcredist-2010.x86.exe https://download.microsoft.com/download/1/6/5/165255E7-1014-4D0A-B094-B6A430A6BFFC/vcredist_x86.exe"
-- name: dotnet-48-installer
-  type: command-runner
-  icon: link-variant
-  source:
-    version_key: "dotnet-installer"
-    check_command: "echo https://go.microsoft.com/fwlink/?linkid=2088631"
-    in_command:    "curl --location --silent --fail --output $1/dotnet-48-installer.exe https://go.microsoft.com/fwlink/?linkid=2088631"
-- name: dotnet-48-patch
-  type: command-runner
-  icon: link-variant
-  source:
-    version_key: "dotnet-48-patch"
-    check_command: "echo https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2024/07/windows10.0-kb5041974-x64-ndp48_e8660214346c8ac124e2f99aa21eef697fff307d.msu"
-    in_command:    "curl --location --silent --fail --output $1/dotnet-48-patch.msu https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/updt/2024/07/windows10.0-kb5041974-x64-ndp48_e8660214346c8ac124e2f99aa21eef697fff307d.msu"
 - name: rewrite-msi
   type: command-runner
   icon: link-variant
@@ -141,8 +127,6 @@ jobs:
     - get: vcredist-ucrt-x86
     - get: vcredist-2010
     - get: vcredist-2010-x86
-    - get: dotnet-48-installer
-    - get: dotnet-48-patch
     - get: rewrite-msi
     - get: version
       params: {bump: patch}
@@ -155,10 +139,8 @@ jobs:
       input-03: vcredist-ucrt-x86
       input-04: vcredist-2010-x86
       input-05: vcredist-2010
-      input-06: dotnet-48-installer
-      input-07: rewrite-msi
-      input-08: repo
-      input-09: dotnet-48-patch
+      input-06: rewrite-msi
+      input-07: repo
     params:
       COPY_ACTIONS: |
         {input-01/Git-*-64-bit.exe,combined-assets}
@@ -166,10 +148,8 @@ jobs:
         {input-03/vcredis*.exe,combined-assets}
         {input-04/vcredis*.exe,combined-assets}
         {input-05/vcredis*.exe,combined-assets}
-        {input-06/dotnet-48-installer.exe,combined-assets}
-        {input-07/rewrite.msi,combined-assets}
-        {input-08/2019/Dockerfile,combined-assets}
-        {input-09/dotnet-48-patch.msu,combined-assets}
+        {input-06/rewrite.msi,combined-assets}
+        {input-07/2019/Dockerfile,combined-assets}
   - task: build-test-push-windows2016fs
     file: ci/shared/tasks/run-bin-test/windows.yml
     input_mapping:


### PR DESCRIPTION
For `windows2016fs`, we're using an out-of-date .NET Framework version that is susceptible to a couple of CVEs: 

- [CVE-2023-36899](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36899)
- [CVE-2023-36560](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2023-36560)

Patching it should resolve these CVEs.