### PR TITLE
Upgrading Go 1.23 on More ARP releases & repos

### DIFF
--- a/go-version.json
+++ b/go-version.json
@@ -3,9 +3,6 @@
      "releases": {
         "diego": "1.22",
         "garden-runc": "1.22",
-        "healthchecker": "1.22",
-        "nfs-volume": "1.22",
-        "smb-volume": "1.22",
-        "test-log-emitter": "1.22"
+        "healthchecker": "1.22"
     }
 }


### PR DESCRIPTION
Go 1.23
- nfs-volume
- smb-volume
- test-log-emitter