### PR TITLE
Create new pipeline for groot-windows-test docker images

### DIFF
--- a/winc-release/bin/set-repo-pipeline.bash
+++ b/winc-release/bin/set-repo-pipeline.bash
@@ -12,6 +12,8 @@ main() {
   fly_pipeline winc-release -f "${pipeline_dir}/winc-release.yml" \
     -f "$REPO/index.yml" \
     -f "$REPO/../shared/helpers/ytt-helpers.star"
+
+  fly_pipeline winc-docker-images -f "${pipeline_dir}/winc-docker-images.yml"
 }
 
 main

--- a/winc-release/dockerfiles/Makefile
+++ b/winc-release/dockerfiles/Makefile
@@ -1,0 +1,25 @@
+all: check-env clean groot-windows-test-link groot-windows-test-regularfile groot-windows-test-servercore groot-windows-test-whiteout
+
+groot-windows-test-link: check-env
+	docker build -t cloudfoundry/groot-windows-test:link ./link
+
+groot-windows-test-regularfile: check-env
+	docker build -t cloudfoundry/groot-windows-test:regularfile ./regularfile
+
+groot-windows-test-servercore: check-env
+	docker build -t cloudfoundry/groot-windows-test:servercore ./servercore
+
+groot-windows-test-whiteout: check-env
+	docker build -t cloudfoundry/groot-windows-test:whiteout ./whiteout
+
+clean: check-env
+	rm -f $(LOCATION)/*.tar
+	docker rm -f groot-windows-test:link
+	docker rm -f groot-windows-test:regularfile
+	docker rm -f groot-windows-test:servercore
+	docker rm -f groot-windows-test:whiteout
+
+check-env:
+ifndef LOCATION
+	$(error LOCATION environment variable is undefined)
+endif

--- a/winc-release/dockerfiles/link/Dockerfile
+++ b/winc-release/dockerfiles/link/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+LABEL org.cloudfoundry.groot-windows-test-link.dockerfile.url="https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/winc-release/dockerfiles/link/Dockerfile"
+LABEL org.cloudfoundry.groot-windows-test-link.notes.md="Used by winc-release \
+"
+
+USER Administrator
+RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello
+RUN mklink C:\temp\symlinkfile C:\temp\test\hello
+RUN mklink /H C:\temp\hardlinkfile C:\temp\test\hello
+RUN mklink /D C:\temp\symlinkdir C:\temp\test
+RUN mklink /J C:\temp\junctiondir C:\temp\test

--- a/winc-release/dockerfiles/metadata.yml
+++ b/winc-release/dockerfiles/metadata.yml
@@ -1,0 +1,8 @@
+---
+readme:
+  This directory contains the dockerfiles needed for diego-release.
+opsfiles:
+  link: For testing symbolick links
+  regularfile: For testing standard files
+  servercore: For testing images based on servercore
+  whiteout: For testing whiteout files (files that have been removed)

--- a/winc-release/dockerfiles/regularfile/Dockerfile
+++ b/winc-release/dockerfiles/regularfile/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+LABEL org.cloudfoundry.groot-windows-test-regularfile.dockerfile.url="https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/winc-release/dockerfiles/regularfile/Dockerfile"
+LABEL org.cloudfoundry.groot-windows-test-regularfile.notes.md="Used by winc-release \
+"
+
+RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello

--- a/winc-release/dockerfiles/servercore/Dockerfile
+++ b/winc-release/dockerfiles/servercore/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/windows/servercore:1809
+
+LABEL org.cloudfoundry.groot-windows-test-servercore.dockerfile.url="https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/winc-release/dockerfiles/servercore/Dockerfile"
+LABEL org.cloudfoundry.groot-windows-test-servercore.notes.md="Used by winc-release \
+"
+
+RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello

--- a/winc-release/dockerfiles/whiteout/Dockerfile
+++ b/winc-release/dockerfiles/whiteout/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/windows/nanoserver:1809
+
+LABEL org.cloudfoundry.groot-windows-test-whiteout.dockerfile.url="https://github.com/cloudfoundry/wg-app-platform-runtime-ci/blob/main/winc-release/dockerfiles/whiteout/Dockerfile"
+LABEL org.cloudfoundry.groot-windows-test-whiteout.notes.md="Used by winc-release \
+"
+
+RUN mkdir C:\temp\test & echo hello > C:\temp\test\hello
+RUN del /f C:\temp\test\hello
+
+RUN echo hello2 > C:\temp\test\hello2

--- a/winc-release/pipelines/winc-docker-images.yml
+++ b/winc-release/pipelines/winc-docker-images.yml
@@ -1,0 +1,256 @@
+---
+resource_types:
+- name: command-runner
+  type: docker-image
+  source:
+    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundrydevelopers/command-runner-resource
+    username: _json_key
+    password: ((gcp-tas-runtime-service-account/config-json))
+    tag: latest
+
+resources:
+- name: groot-windows-test-link-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - winc-release/dockerfiles/link/Dockerfile
+
+- name: groot-windows-test-regularfile-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - winc-release/dockerfiles/regularfile/Dockerfile
+
+- name: groot-windows-test-servercore-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: main
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - winc-release/dockerfiles/servercore/Dockerfile
+
+- name: groot-windows-test-whiteout-dockerfile
+  type: git
+  icon: source-branch
+  source:
+    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci.git
+    branch: groot-windows-docker-images
+    private_key: ((github-tas-runtime-bot/private-key))
+    paths:
+    - winc-release/dockerfiles/whiteout/Dockerfile
+
+- name: ci
+  type: git
+  icon: source-branch
+  source:
+    branch: groot-windows-docker-images
+    uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
+
+- name: image
+  type: registry-image
+  icon: docker
+  source:
+    repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/tas-runtime-build
+    username: _json_key
+    password: ((gcp-tas-runtime-service-account/config-json))
+
+- name: http-golang-download
+  type: command-runner
+  icon: link-variant
+  source:
+    version_key: "latest-golang"
+    check_command: "echo https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
+    in_command:    "curl --silent --fail --output $1/golang.tgz https://dl.google.com/go/$(curl -s https://go.dev/dl/?mode=json | grep -o 'go.*.linux-amd64.tar.gz' | head -n 1 | tr -d '\r\n')"
+
+- name: windows-worker-lock
+  type: pool
+  icon: cloud-lock
+  source:
+    branch: main
+    pool: windows-worker-lock
+    private_key: ((github-tas-runtime-bot/private-key))
+    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
+
+jobs:
+- name: groot-windows-test-link
+  serial: true
+  plan:
+  - in_parallel:
+    - get: http-golang-download
+      trigger: true
+    - get: groot-windows-test-link-dockerfile
+      trigger: true
+    - get: ci
+    - get: image
+  - put: windows-worker-lock
+    params:
+      acquire: true
+  - task: start-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-start/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+  - task: build-push-groot-windows-dockerfile
+    file: ci/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
+    params:
+      ENVS: |
+        IMAGE_NAME=cloudfoundry/groot-windows-test
+        IMAGE_TAG=link
+        DOCKERFILE=$PWD/ci/winc-release/dockerfiles/link/Dockerfile
+        DOCKER_USERNAME=((dockerhub-tasruntime-username))
+        DOCKER_PASSWORD=((dockerhub-tasruntime-password))
+  ensure:
+    task: stop-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-stop/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+    ensure:
+      put: windows-worker-lock
+      inputs: detect
+      params:
+        release: windows-worker-lock
+
+- name: groot-windows-test-regularfile
+  serial: true
+  plan:
+  - in_parallel:
+    - get: http-golang-download
+      trigger: true
+    - get: groot-windows-test-regularfile-dockerfile
+      trigger: true
+    - get: ci
+    - get: image
+  - put: windows-worker-lock
+    params:
+      acquire: true
+  - task: start-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-start/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+  - task: build-push-groot-windows-dockerfile
+    file: ci/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
+    params:
+      ENVS: |
+        IMAGE_NAME=cloudfoundry/groot-windows-test
+        IMAGE_TAG=regularfile
+        DOCKERFILE=$PWD/ci/winc-release/dockerfiles/regularfile/Dockerfile
+        DOCKER_USERNAME=((dockerhub-tasruntime-username))
+        DOCKER_PASSWORD=((dockerhub-tasruntime-password))
+  ensure:
+    task: stop-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-stop/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+    ensure:
+      put: windows-worker-lock
+      inputs: detect
+      params:
+        release: windows-worker-lock
+
+- name: groot-windows-test-servercore
+  serial: true
+  plan:
+  - in_parallel:
+    - get: http-golang-download
+      trigger: true
+    - get: groot-windows-test-servercore-dockerfile
+      trigger: true
+    - get: ci
+    - get: image
+  - put: windows-worker-lock
+    params:
+      acquire: true
+  - task: start-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-start/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+  - task: build-push-groot-windows-dockerfile
+    file: ci/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
+    params:
+      ENVS: |
+        IMAGE_NAME=cloudfoundry/groot-windows-test
+        IMAGE_TAG=servercore
+        DOCKERFILE=$PWD/ci/winc-release/dockerfiles/servercore/Dockerfile
+        DOCKER_USERNAME=((dockerhub-tasruntime-username))
+        DOCKER_PASSWORD=((dockerhub-tasruntime-password))
+  ensure:
+    task: stop-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-stop/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+    ensure:
+      put: windows-worker-lock
+      inputs: detect
+      params:
+        release: windows-worker-lock
+
+- name: groot-windows-test-whiteout
+  serial: true
+  plan:
+  - in_parallel:
+    - get: http-golang-download
+      trigger: true
+    - get: groot-windows-test-whiteout-dockerfile
+      trigger: true
+    - get: ci
+    - get: image
+  - put: windows-worker-lock
+    params:
+      acquire: true
+  - task: start-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-start/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+  - task: build-push-groot-windows-dockerfile
+    file: ci/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
+    params:
+      ENVS: |
+        IMAGE_NAME=cloudfoundry/groot-windows-test
+        IMAGE_TAG=whiteout
+        DOCKERFILE=$PWD/ci/winc-release/dockerfiles/whiteout/Dockerfile
+        DOCKER_USERNAME=((dockerhub-tasruntime-username))
+        DOCKER_PASSWORD=((dockerhub-tasruntime-password))
+  ensure:
+    task: stop-windows-worker
+    image: image
+    file: ci/shared/tasks/bosh-stop/linux.yml
+    params:
+      DEPLOYMENT: windows-worker
+      INSTANCE_GROUP: windows-worker
+      BOSH_CREDS: ((bosh-concourse-credentials/env_vars))
+    ensure:
+      put: windows-worker-lock
+      inputs: detect
+      params:
+        release: windows-worker-lock
+

--- a/winc-release/tasks/build-push-groot-windows-dockerfile/metadata.yml
+++ b/winc-release/tasks/build-push-groot-windows-dockerfile/metadata.yml
@@ -1,0 +1,15 @@
+---
+readme: |
+  This task will build a dockerfile for the groot-windows test suite and push it to DockerHub.
+oses:
+  - windows
+params:
+  DEFAULT_PARAMS: Path to .yml file containing repo's default-params to use instead. If this value is set, it will override other params set explicitly.
+  ENVS: |
+    This parameter defines a list of environment variables will be loaded at runtime, as opposed to
+    container-creation time. The purpose here is to allow users to extend the list of environment
+    variables used by the task simply by updating the pipeline config, rather than by updating the task definition
+    in windows.yml.
+  DOCKERFILE: Path to the dockerfile to be built
+  DOCKER_USERNAME: Username for login to DockerHub
+  DOCKER_PASSWORD: Password for login to DockerHub

--- a/winc-release/tasks/build-push-groot-windows-dockerfile/task.ps1
+++ b/winc-release/tasks/build-push-groot-windows-dockerfile/task.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
+. "$PSScriptRoot\..\..\..\shared\helpers\helpers.ps1"
+if ([System.IO.File]::Exists($env:DEFAULT_PARAMS)) {
+    Debug "Extract-Default-Params-For-Task with values from ${env:DEFAULT_PARAMS}"
+    Extract-Default-Params-For-Task "$env:DEFAULT_PARAMS"
+}
+
+function Run-Docker {
+    param([String[]] $cmd)
+
+    docker @cmd
+    if ($LASTEXITCODE -ne 0) {
+        Exit $LASTEXITCODE
+    }
+}
+
+function Run
+{
+    Expand-Envs
+
+    Restart-Service docker
+
+    Run-Docker "--version"
+
+    Write-Host "Building image ${env:IMAGE_NAME}:${env:IMAGE_TAG}"
+    Run-Docker "build", "-t", "${env:IMAGE_NAME}:${env:IMAGE_TAG}", "-f", "${env:DOCKERFILE}", "."
+
+    Run-Docker "images", "-a"
+    Run-Docker "login", "-u", "${env:DOCKER_USERNAME}", "-p", "${env:DOCKER_PASSWORD}"
+    Run-Docker "push", "${env:IMAGE_NAME}:${env:IMAGE_TAG}"
+}
+
+Run

--- a/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
+++ b/winc-release/tasks/build-push-groot-windows-dockerfile/windows.yml
@@ -1,0 +1,18 @@
+---
+platform: windows
+
+inputs:
+- name: ci
+
+params:
+  DEFAULT_PARAMS:
+  ENVS:
+
+run:
+  path: powershell
+  args:
+  - "-ExecutionPolicy"
+  - "Bypass"
+  - "-File"
+  - ci/winc-release/tasks/build-push-groot-windows-dockerfile/task.ps1
+


### PR DESCRIPTION
The `cloudfoundry/groot-windows-test` images were very (7 years) out of date.  Let's create a pipeline to handle it.

- Add winc-docker-images pipeline
- Add new winc-release task to build and push groot-windows dockerfiles