### PR TITLE
Increase frequency of the bump-dependencies-go-mod to daily

### DIFF
--- a/cf-networking-release/pipelines/cf-networking-release.yml
+++ b/cf-networking-release/pipelines/cf-networking-release.yml
@@ -301,7 +301,7 @@ jobs:
       - get: cf-networking-repo
       - get: silk-repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - in_parallel:
     - do:

--- a/diego-release/pipelines/diego-release.yml
+++ b/diego-release/pipelines/diego-release.yml
@@ -225,6 +225,14 @@ resources:
     start: 00:00
     stop: 00:59
 
+- name: daily-at-1-oclock
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 01:00
+    stop: 01:59
+
 - name: weekly
   type: time
   icon: clock
@@ -342,7 +350,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-1-oclock
         trigger: true
   - task: diego-release-bump-dependencies-go-mod
     image: image

--- a/envoy-nginx-release/pipelines/envoy-nginx-release.yml
+++ b/envoy-nginx-release/pipelines/envoy-nginx-release.yml
@@ -141,6 +141,14 @@ resources:
     days:
       - Wednesday
 
+- name: daily-at-midnight
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 00:00
+    stop: 00:59
+
 - name: env
   type: shepherd
   icon: sheep
@@ -225,7 +233,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: envoy-nginx-release-bump-dependencies-go-mod
     image: image

--- a/garden-runc-release/pipelines/garden-runc-release.yml
+++ b/garden-runc-release/pipelines/garden-runc-release.yml
@@ -237,6 +237,14 @@ resources:
     days:
       - Wednesday
 
+- name: daily-at-midnight
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 00:00
+    stop: 00:59
+
 #! Toolsmith pool
 - name: env
   type: shepherd
@@ -493,7 +501,7 @@ jobs:
     - get: updated-go-mod-garden-integration-tests
     - get: updated-go-mod-dontpanic
     - get: image
-    - get: weekly
+    - get: daily-at-midnight
       trigger: true
   - do:
     - task: garden-bump-dependencies-go-mod

--- a/healthchecker-release/pipelines/healthchecker-release.yml
+++ b/healthchecker-release/pipelines/healthchecker-release.yml
@@ -204,7 +204,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: healthchecker-release-bump-dependencies-go-mod
     image: image

--- a/mapfs-release/pipelines/mapfs-release.yml
+++ b/mapfs-release/pipelines/mapfs-release.yml
@@ -334,7 +334,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - do:
     - task: mapfs-release-bump-dependencies-go-mod

--- a/nats-release/pipelines/nats-release.yml
+++ b/nats-release/pipelines/nats-release.yml
@@ -229,7 +229,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: nats-release-bump-dependencies-go-mod
     image: image

--- a/nfs-volume-release/pipelines/nfs-volume-release.yml
+++ b/nfs-volume-release/pipelines/nfs-volume-release.yml
@@ -322,7 +322,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: nfs-volume-release-bump-dependencies-go-mod
     image: image

--- a/routing-release/pipelines/routing-release.yml
+++ b/routing-release/pipelines/routing-release.yml
@@ -337,7 +337,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: routing-release-bump-dependencies-go-mod
     image: image

--- a/smb-volume-release/pipelines/smb-volume-release.yml
+++ b/smb-volume-release/pipelines/smb-volume-release.yml
@@ -298,7 +298,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: smb-volume-release-bump-dependencies-go-mod
     image: image

--- a/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
+++ b/wg-arp-diego-modules/pipelines/wg-arp-diego-modules.yml
@@ -305,7 +305,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/wg-arp-garden-modules/pipelines/wg-arp-garden-modules.yml
+++ b/wg-arp-garden-modules/pipelines/wg-arp-garden-modules.yml
@@ -395,7 +395,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
+++ b/wg-arp-networking-modules/pipelines/wg-arp-networking-modules.yml
@@ -306,7 +306,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/wg-arp-volume-services-modules/pipelines/wg-arp-volume-services-modules.yml
+++ b/wg-arp-volume-services-modules/pipelines/wg-arp-volume-services-modules.yml
@@ -234,7 +234,7 @@ jobs:
       - resource: #@ package.name
         get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: #@ "bump-dependencies-{}".format(package.name)
     image: image

--- a/winc-release/pipelines/winc-release.yml
+++ b/winc-release/pipelines/winc-release.yml
@@ -229,6 +229,14 @@ resources:
     days:
       - Wednesday
 
+- name: daily-at-midnight
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 00:00
+    stop: 00:59
+
 - name: github-release
   type: github-release
   icon: github
@@ -347,7 +355,7 @@ jobs:
       - get: updated-go-mod-diff-exporter
       - get: updated-go-mod-groot-windows
       - get: updated-go-mod-winc
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - do:
     - task: cert-injector-bump-dependencies-go-mod

--- a/windows2019fs-release/pipelines/windows2019fs-release.yml
+++ b/windows2019fs-release/pipelines/windows2019fs-release.yml
@@ -185,6 +185,14 @@ resources:
     days:
       - Wednesday
 
+- name: daily-at-midnight
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 00:00
+    stop: 00:59
+
 #! Define-Jobs
 jobs:
 - name: bump-dependencies-go-mod
@@ -195,7 +203,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: windows2019fs-release-bump-dependencies-go-mod
     image: image

--- a/windowsfs-online-release/pipelines/windowsfs-online-release.yml
+++ b/windowsfs-online-release/pipelines/windowsfs-online-release.yml
@@ -186,6 +186,14 @@ resources:
     days:
       - Wednesday
 
+- name: daily-at-midnight
+  type: time
+  icon: clock
+  source:
+    interval: '24h'
+    start: 00:00
+    stop: 00:59
+
 #! Define-Jobs
 jobs:
 - name: bump-dependencies-go-mod
@@ -196,7 +204,7 @@ jobs:
       - get: ci
       - get: repo
       - get: image
-      - get: weekly
+      - get: daily-at-midnight
         trigger: true
   - task: windowsfs-online-bump-dependencies-go-mod
     image: image


### PR DESCRIPTION
Currently, not all Diego versions include guardian with up-to-date dependency versions in the go.mod file. This is reflected in failed BlackDuck scans for the Diego release, as the guardian component does not have up-to-date dependency versions in the go.mod file.
By running the bump-dependencies-go-mod job daily, we would have more often up-to-date versions of all the components, including guardian and up-to-date go.mod file. The successful BlackDuck scans will allow us to react immediately to security vulnerabilities. 