### PR TITLE
Upgrade Garden to Containerd v2.0

### DIFF
--- a/garden-runc-release/default-params/build-binaries/linux.yml
+++ b/garden-runc-release/default-params/build-binaries/linux.yml
@@ -11,6 +11,6 @@ params:
     build_init=src/guardian/cmd/init
     build_dadoo=src/guardian/cmd/dadoo
     build_idmapper=src/idmapper
-    build_containerd=src/guardian/vendor/github.com/containerd/containerd
+    build_containerd=src/containerd
   FUNCTIONS: ci/garden-runc-release/helpers/build-binaries.bash
 

--- a/garden-runc-release/helpers/build-binaries.bash
+++ b/garden-runc-release/helpers/build-binaries.bash
@@ -334,21 +334,16 @@ function build_containerd() {
     target="$target/containerd"
     mkdir -p "${target}"
 
-    verify_go
-
     pushd "$source" || exit
     BUILDTAGS=no_btrfs make ./bin/containerd
-    BUILDTAGS=no_btrfs make ./bin/containerd-shim
-    BUILDTAGS=no_btrfs make ./bin/containerd-shim-runc-v1
     BUILDTAGS=no_btrfs make ./bin/containerd-shim-runc-v2
     BUILDTAGS=no_btrfs make ./bin/ctr
     mv -f bin/* "${target}"
+
     popd || exit
 
     cat > "${target}/run.bash" << EOF
 export CONTAINERD_BINARY="\$PWD/${built_dir}/containerd/containerd"
-export CONTAINERD_SHIM_BINARY="\$PWD/${built_dir}/containerd/containerd-shim"
-export CONTAINERD_SHIM_RUNC_V1_BINARY="\$PWD/${built_dir}/containerd/containerd-shim-runc-v1"
 export CONTAINERD_SHIM_RUNC_V2_BINARY="\$PWD/${built_dir}/containerd/containerd-shim-runc-v2"
 export CONTAINERD_CTR_BINARY="\$PWD/${built_dir}/containerd/ctr"
 EOF

--- a/garden-runc-release/linters/sync-package-specs.bash
+++ b/garden-runc-release/linters/sync-package-specs.bash
@@ -15,18 +15,12 @@ function run() {
 
   pushd "${repo_path}" > /dev/null
 
-  BUILD_FLAGS="--tags cgo,no_btrfs" sync_package containerd guardian \
-    -app github.com/containerd/containerd/cmd/ctr \
-    -app github.com/containerd/containerd/cmd/containerd \
-    -app github.com/containerd/containerd/cmd/containerd-shim \
-    -app github.com/containerd/containerd/cmd/containerd-shim-runc-v1 \
-    -app github.com/containerd/containerd/cmd/containerd-shim-runc-v2 &
-
-  BUILD_FLAGS="--tags cgo,seccomp,apparmor" sync_package runc guardian \
+  BUILD_FLAGS="--tags cgo,seccomp" sync_package runc guardian \
     -app github.com/opencontainers/runc &
 
   BUILD_FLAGS="--tags cloudfoundry" sync_package grootfs grootfs \
     -app code.cloudfoundry.org/grootfs \
+    -app code.cloudfoundry.org/idmapper \
     -app code.cloudfoundry.org/grootfs/store/filesystems/overlayxfs/tardis &
 
   sync_package gats garden-integration-tests -app github.com/onsi/ginkgo/v2/ginkgo \

--- a/garden-runc-release/linters/sync-submodule-config.bash
+++ b/garden-runc-release/linters/sync-submodule-config.bash
@@ -16,6 +16,7 @@ function run() {
 
   rm -rf /tmp/packages
   cat > /tmp/packages <<EOF
+containerd
 dontpanic
 garden
 garden-integration-tests


### PR DESCRIPTION
Containerd 2.0 requires a different way of building the binaries. We now need to submodule Containerd to include all makefiles as vendoring no longer includes them.

Please see other PR's as they are all interdependent:
https://github.com/cloudfoundry/garden-runc-release/pull/368/
https://github.com/cloudfoundry/guardian/pull/466
