### PR TITLE
Change param build-release-notes task in GITHUB_ORG --> GITHUB_ORG_URL

### DIFF
--- a/shared/tasks/build-release-notes/linux.yml
+++ b/shared/tasks/build-release-notes/linux.yml
@@ -16,7 +16,7 @@ outputs:
 
 params:
   BOSH_IO_ORG: cloudfoundry
-  GITHUB_ORG:  cloudfoundry
+  GITHUB_ORG_URL: https://github.com/cloudfoundry
 
 run:
   path: ci/shared/tasks/build-release-notes/task.bash

--- a/shared/tasks/build-release-notes/metadata.yml
+++ b/shared/tasks/build-release-notes/metadata.yml
@@ -8,4 +8,4 @@ oses:
   - linux
 params:
   BOSH_IO_ORG: The name of the org used on bosh.io for boshrelease links. Defaults to 'cloudfoundry'
-  GITHUB_ORG:  The name of the github org to use for release note links. Defaults to 'cloudfoundry'
+  GITHUB_ORG_URL:  The URL of the github org to use for release note links. Defaults to 'https://github.com/cloudfoundry'

--- a/shared/tasks/build-release-notes/task.bash
+++ b/shared/tasks/build-release-notes/task.bash
@@ -73,7 +73,7 @@ function run(){
 ${spec_diff}
 ${built_with_go}
 
-**Full Changelog**: https://github.com/${GITHUB_ORG}/${repo_name}/compare/${old_version}...${new_tag_version}
+**Full Changelog**: ${GITHUB_ORG_URL}/${repo_name}/compare/${old_version}...${new_tag_version}
 
 ${bosh_io_resources}
 ${extra_metadata:-}


### PR DESCRIPTION
This will allow the task to be used for projects on hosted githubs. There are no OSS uses of the original GITHUB_ORG env var.