### PR TITLE
Go back to using one env-lock and the new check_unclaimed feature on a forked pool resource

### DIFF
--- a/cf-networking-release/pipelines/cf-networking-release.yml
+++ b/cf-networking-release/pipelines/cf-networking-release.yml
@@ -35,16 +35,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-prepare-env
-  - release-work-lock-export-release
-  - release-work-lock-cf-networking-acceptance
-  - release-work-lock-service-discovery-acceptance
-  - release-work-lock-service-discovery-performance
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -61,6 +56,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -241,18 +241,13 @@ resources:
     days:
       - Monday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: 1m
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: 1m
@@ -330,73 +325,14 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: cf-networking-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
     pool: cf-networking-release-env-lock
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-
-- name: cf-networking-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-cats
-
-- name: cf-networking-release-lock-cf-networking-acceptance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-cf-networking-acceptance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-cf-networking-acceptance
-
-- name: cf-networking-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-export-release
-
-- name: cf-networking-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-prepare-env
-
-- name: cf-networking-release-lock-service-discovery-acceptance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-service-discovery-acceptance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-service-discovery-acceptance
-
-- name: cf-networking-release-lock-service-discovery-performance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: cf-networking-release-lock-service-discovery-performance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: cf-networking-release-lock-service-discovery-performance
+    paths: cf-networking-release-env-lock
 
 - name: image
   type: registry-image
@@ -413,10 +349,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -808,27 +740,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: cf-networking-release-lock-prepare-env
+      - put: cf-networking-release-env-lock
         params:
-          release: cf-networking-release-lock-prepare-env
-      - put: cf-networking-release-lock-cats
-        params:
-          release: cf-networking-release-lock-cats
-      - put: cf-networking-release-lock-cf-networking-acceptance
-        params:
-          release: cf-networking-release-lock-cf-networking-acceptance
-      - put: cf-networking-release-lock-export-release
-        params:
-          release: cf-networking-release-lock-export-release
-      - put: cf-networking-release-lock-service-discovery-acceptance
-        params:
-          release: cf-networking-release-lock-service-discovery-acceptance
-      - put: cf-networking-release-lock-service-discovery-performance
-        params:
-          release: cf-networking-release-lock-service-discovery-performance
-  on_failure: *release-work-locks
+          release: cf-networking-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -843,34 +760,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: cf-networking-release-env-lock
-  - get: cf-networking-release-lock-cats
-  - get: cf-networking-release-lock-cf-networking-acceptance
-  - get: cf-networking-release-lock-export-release
-  - get: cf-networking-release-lock-prepare-env
-  - get: cf-networking-release-lock-service-discovery-acceptance
-  - get: cf-networking-release-lock-service-discovery-performance
+    - get: cf-networking-release-env-lock
   - put: cf-networking-release-env-lock
     params:
       claim: cf-networking-release-env-lock
-  - put: cf-networking-release-lock-cats
-    params:
-      claim: cf-networking-release-lock-cats
-  - put: cf-networking-release-lock-cf-networking-acceptance
-    params:
-      claim: cf-networking-release-lock-cf-networking-acceptance
-  - put: cf-networking-release-lock-export-release
-    params:
-      claim: cf-networking-release-lock-export-release
-  - put: cf-networking-release-lock-prepare-env
-    params:
-      claim: cf-networking-release-lock-prepare-env
-  - put: cf-networking-release-lock-service-discovery-acceptance
-    params:
-      claim: cf-networking-release-lock-service-discovery-acceptance
-  - put: cf-networking-release-lock-service-discovery-performance
-    params:
-      claim: cf-networking-release-lock-service-discovery-performance
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -888,12 +781,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: cf-networking-release-lock-prepare-env
-    params:
-      release: cf-networking-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -911,19 +800,7 @@ jobs:
       trigger: true
     - get: cf-networking-release-env-lock
       passed: [ claim-env ]
-    - get: cf-networking-release-lock-cats
-      passed: [ claim-env ]
-    - get: cf-networking-release-lock-cf-networking-acceptance
-      passed: [ claim-env ]
-    - get: cf-networking-release-lock-export-release
-      passed: [ claim-env ]
-    - get: cf-networking-release-lock-prepare-env
-      passed: [ claim-env ]
-    - get: cf-networking-release-lock-service-discovery-acceptance
-      passed: [ claim-env ]
-    - get: cf-networking-release-lock-service-discovery-performance
-      passed: [ claim-env ]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1046,10 +923,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: cf-networking-release-lock-cats
-    params:
-      release: cf-networking-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -1066,8 +939,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: cf-networking-release-lock-cats
-      passed: [ prepare-env ]
   - task: create-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1088,10 +959,6 @@ jobs:
 - name: run-service-discovery-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: cf-networking-release-lock-service-discovery-acceptance
-    params:
-      release: cf-networking-release-lock-service-discovery-acceptance
   plan:
   - in_parallel:
     - get: ci
@@ -1110,8 +977,6 @@ jobs:
     - get: cf-deployment
     - get: package-release
       resource: golang-release-latest
-    - get: cf-networking-release-lock-service-discovery-acceptance
-      passed: [ prepare-env ]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -1148,10 +1013,6 @@ jobs:
 - name: run-cf-networking-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: cf-networking-release-lock-cf-networking-acceptance
-    params:
-      release: cf-networking-release-lock-cf-networking-acceptance
   plan:
   - in_parallel:
     - get: ci
@@ -1170,8 +1031,6 @@ jobs:
     - get: cf-deployment
     - get: package-release
       resource: golang-release-latest
-    - get: cf-networking-release-lock-cf-networking-acceptance
-      passed: [ prepare-env ]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -1206,10 +1065,6 @@ jobs:
 
 - name: run-service-discovery-performance-tests
   serial: true
-  ensure:
-    put: cf-networking-release-lock-service-discovery-performance
-    params:
-      release: cf-networking-release-lock-service-discovery-performance
   plan:
   - in_parallel:
     - get: cf-networking-repo
@@ -1224,9 +1079,7 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: ci
     - get: image
-    - get: cf-networking-release-lock-service-discovery-performance
-      passed: [ prepare-env ]
-  - try:
+  - try: &delete-sdpt-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1260,10 +1113,6 @@ jobs:
 
 - name: export-release
   serial: true
-  ensure:
-    put: cf-networking-release-lock-export-release
-    params:
-      release: cf-networking-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1278,8 +1127,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: cf-networking-release-lock-export-release
-      passed: [ prepare-env ]
   - task: cf-networking-export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1494,52 +1341,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: cf-networking-release-env-lock
-  - get: cf-networking-release-lock-cats
-  - get: cf-networking-release-lock-cf-networking-acceptance
-  - get: cf-networking-release-lock-export-release
-  - get: cf-networking-release-lock-prepare-env
-  - get: cf-networking-release-lock-service-discovery-acceptance
-  - get: cf-networking-release-lock-service-discovery-performance
-  - put: check-lock-prepare-env
-    resource: cf-networking-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: cf-networking-release-env-lock
     params:
-      check: cf-networking-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: cf-networking-release-lock-cats
-    params:
-      check: cf-networking-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-cf-networking-acceptance
-    resource: cf-networking-release-lock-cf-networking-acceptance
-    params:
-      check: cf-networking-release-lock-cf-networking-acceptance
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: cf-networking-release-lock-export-release
-    params:
-      check: cf-networking-release-lock-export-release
-      retry-delay: 10m
-  - put: check-lock-service-discovery-acceptance
-    resource: cf-networking-release-lock-service-discovery-acceptance
-    params:
-      check: cf-networking-release-lock-service-discovery-acceptance
-      retry-delay: 10m
-  - put: check-lock-service-discovery-performance
-    resource: cf-networking-release-lock-service-discovery-performance
-    params:
-      check: cf-networking-release-lock-service-discovery-performance
-      retry-delay: 10m
+      check_unclaimed: cf-networking-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: cf-networking-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 4h
 
 - name: cleanup-env
   serial: true
@@ -1552,125 +1384,46 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: cf-networking-release-env-lock
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-cats
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-cf-networking-acceptance
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-service-discovery-acceptance
-        passed: [ check-work-locks ]
-      - get: cf-networking-release-lock-service-discovery-performance
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-cfnetworking-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-cfnetworking-env
-          DEPLOYMENT_NAME: service-discovery-performance-tests
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-cfnetworking-env
-          SUSPEND: false
-  - try:
-      put: cf-networking-release-env-lock
-      params:
-        release: cf-networking-release-env-lock
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-cats
-  - put: cf-networking-release-lock-cats
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-sdpt-deployment
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: cf-networking-release-lock-cats
-
-- name: release-work-lock-cf-networking-acceptance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-cf-networking-acceptance
-  - put: cf-networking-release-lock-cf-networking-acceptance
-    params:
-      release: cf-networking-release-lock-cf-networking-acceptance
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-export-release
-  - put: cf-networking-release-lock-export-release
-    params:
-      release: cf-networking-release-lock-export-release
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-prepare-env
-  - put: cf-networking-release-lock-prepare-env
-    params:
-      release: cf-networking-release-lock-prepare-env
-
-- name: release-work-lock-service-discovery-acceptance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-service-discovery-acceptance
-  - put: cf-networking-release-lock-service-discovery-acceptance
-    params:
-      release: cf-networking-release-lock-service-discovery-acceptance
-
-- name: release-work-lock-service-discovery-performance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: cf-networking-release-lock-service-discovery-performance
-  - put: cf-networking-release-lock-service-discovery-performance
-    params:
-      release: cf-networking-release-lock-service-discovery-performance
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-cfnetworking-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
   - get: cf-networking-release-env-lock
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - put: cf-networking-release-env-lock
-    params:
-      release: cf-networking-release-env-lock
+  - try: *release-env-lock
 
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-sdpt-deployment
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
+    params:
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-cfnetworking-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/diego-release/pipelines/diego-release.yml
+++ b/diego-release/pipelines/diego-release.yml
@@ -36,16 +36,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-bosh-restart
-  - release-work-lock-cats
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-vizzini
-  - release-work-lock-wats
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -65,11 +60,17 @@ resource_types:
     tag: latest
     username: _json_key
     password: ((gcp-wg-arp-service-account/config-json))
+
 - name: slack-notification
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -259,18 +260,13 @@ resources:
     days:
       - Wednesday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -322,7 +318,7 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: diego-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -330,66 +326,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: diego-release-env-lock
-
-- name: diego-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-prepare-env 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-prepare-env
-
-- name: diego-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-cats 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-cats
-
-- name: diego-release-lock-wats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-wats 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-wats
-
-- name: diego-release-lock-vizzini
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-vizzini 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-vizzini
-
-- name: diego-release-lock-bosh-restart
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-bosh-restart 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-bosh-restart
-
-- name: diego-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: diego-release-lock-export-release 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: diego-release-lock-export-release
 
 - name: image
   type: registry-image
@@ -445,10 +381,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -1142,28 +1074,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
-    in_parallel:
-      steps:
-      - put: diego-release-lock-prepare-env
+  on_abort: &release-env-lock
+    do:
+      - put: diego-release-env-lock
         params:
-          release: diego-release-lock-prepare-env
-      - put: diego-release-lock-bosh-restart
-        params:
-          release: diego-release-lock-bosh-restart
-      - put: diego-release-lock-cats
-        params:
-          release: diego-release-lock-cats
-      - put: diego-release-lock-export-release
-        params:
-          release: diego-release-lock-export-release
-      - put: diego-release-lock-vizzini
-        params:
-          release: diego-release-lock-vizzini
-      - put: diego-release-lock-wats
-        params:
-          release: diego-release-lock-wats
-  on_failure: *release-work-locks
+          release: diego-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -1175,31 +1091,9 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: diego-release-env-lock
-  - get: diego-release-lock-prepare-env
-  - get: diego-release-lock-bosh-restart
-  - get: diego-release-lock-cats
-  - get: diego-release-lock-export-release
-  - get: diego-release-lock-vizzini
-  - get: diego-release-lock-wats
-  - put: diego-release-lock-prepare-env
-    params:
-      claim: diego-release-lock-prepare-env
-  - put: diego-release-lock-bosh-restart
-    params:
-      claim: diego-release-lock-bosh-restart
-  - put: diego-release-lock-cats
-    params:
-      claim: diego-release-lock-cats
-  - put: diego-release-lock-export-release
-    params:
-      claim: diego-release-lock-export-release
-  - put: diego-release-lock-vizzini
-    params:
-      claim: diego-release-lock-vizzini
-  - put: diego-release-lock-wats
-    params:
-      claim: diego-release-lock-wats
+    - get: diego-release-env-lock
+      params:
+        claim: diego-release-env-lock
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -1218,12 +1112,8 @@ jobs:
 - name: prepare-env
   serial: true
   serial_groups: [acceptance]
-  on_success:
-    put: diego-release-lock-prepare-env
-    params:
-      release: diego-release-lock-prepare-env 
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -1241,19 +1131,7 @@ jobs:
       resource: golang-release-latest
     - get: diego-release-env-lock
       passed: [ claim-env ]
-    - get: diego-release-lock-prepare-env
-      passed: [ claim-env ]
-    - get: diego-release-lock-bosh-restart
-      passed: [ claim-env ]
-    - get: diego-release-lock-cats
-      passed: [ claim-env ]
-    - get: diego-release-lock-export-release
-      passed: [ claim-env ]
-    - get: diego-release-lock-vizzini
-      passed: [ claim-env ]
-    - get: diego-release-lock-wats
-      passed: [ claim-env ]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1370,10 +1248,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: diego-release-lock-cats
-    params:
-      release: diego-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -1387,8 +1261,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: diego-release-lock-cats
-      passed: [ prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1409,10 +1281,6 @@ jobs:
 - name: run-wats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: diego-release-lock-wats
-    params:
-      release: diego-release-lock-wats
   plan:
   - in_parallel:
     - get: ci
@@ -1426,8 +1294,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: diego-release-lock-wats
-      passed: [ prepare-env]
   - task: create-wats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1451,10 +1317,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: diego-release-lock-export-release
-    params:
-      release: diego-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1466,8 +1328,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: diego-release-lock-export-release
-      passed: [ prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1477,10 +1337,6 @@ jobs:
 - name: run-vizzini
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: diego-release-lock-vizzini
-    params:
-      release: diego-release-lock-vizzini
   plan:
   - in_parallel:
     - get: ci
@@ -1491,8 +1347,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: diego-release-lock-vizzini
-      passed: [ prepare-env]
   - task: vizzini
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -1505,10 +1359,6 @@ jobs:
 - name: run-bosh-restart
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: diego-release-lock-bosh-restart
-    params:
-      release: diego-release-lock-bosh-restart
   plan:
   - in_parallel:
     - get: ci
@@ -1521,8 +1371,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-deployment
     - get: image
-    - get: diego-release-lock-bosh-restart
-      passed: [ prepare-env]
   - task: create-uptimer-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1660,53 +1508,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: diego-release-env-lock
-  - get: diego-release-lock-prepare-env
-  - get: diego-release-lock-bosh-restart
-  - get: diego-release-lock-cats
-  - get: diego-release-lock-export-release
-  - get: diego-release-lock-vizzini
-  - get: diego-release-lock-wats
-  - put: check-lock-prepare-env
-    resource: diego-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: diego-release-env-lock
     params:
-      check: diego-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-bosh-restart
-    resource: diego-release-lock-bosh-restart
-    params:
-      check: diego-release-lock-bosh-restart
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: diego-release-lock-cats
-    params:
-      check: diego-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: diego-release-lock-export-release
-    params:
-      check: diego-release-lock-export-release
-      retry-delay: 10m
-  - put: check-lock-vizzini
-    resource: diego-release-lock-vizzini
-    params:
-      check: diego-release-lock-vizzini
-      retry-delay: 10m
-  - put: check-lock-wats
-    resource: diego-release-lock-wats
-    params:
-      check: diego-release-lock-wats
-      retry-delay: 10m
+      check_unclaimed: diego-release-env-lock
+      retry-delay: 60m
 
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: diego-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 5h
 
 - name: cleanup-env
   serial: true
@@ -1716,120 +1548,47 @@ jobs:
       - get: ci
       - get: env
       - get: image
-  - get: manual-cleanup-trigger
-    trigger: true
-    passed: [ manual-cleanup-trigger ]
-  - get: lock-check-timer
-    trigger: true
-    passed: [ check-work-locks ]
-  - get: diego-release-env-lock
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-prepare-env
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-bosh-restart
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-cats
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-export-release
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-vizzini
-    passed: [ check-work-locks ]
-  - get: diego-release-lock-wats
-    passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-diego-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-diego-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: diego-release-env-lock
-        params:
-          release: diego-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-prepare-env
-  - put: diego-release-lock-prepare-env
+      - get: manual-cleanup-trigger
+        trigger: true
+        passed: [ manual-cleanup-trigger ]
+      - get: diego-release-env-lock
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: diego-release-lock-prepare-env
-
-- name: release-work-lock-bosh-restart
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-bosh-restart
-  - put: diego-release-lock-bosh-restart
-    params:
-      release: diego-release-lock-bosh-restart
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-cats
-  - put: diego-release-lock-cats
-    params:
-      release: diego-release-lock-cats
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-export-release
-  - put: diego-release-lock-export-release
-    params:
-      release: diego-release-lock-export-release
-
-- name: release-work-lock-vizzini
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-vizzini
-  - put: diego-release-lock-vizzini
-    params:
-      release: diego-release-lock-vizzini
-
-- name: release-work-lock-wats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: diego-release-lock-wats
-  - put: diego-release-lock-wats
-    params:
-      release: diego-release-lock-wats
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-diego-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
   - get: diego-release-env-lock
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - put: diego-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: diego-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-diego-env
+      SUSPEND: false
 
 
 #! versioning

--- a/envoy-nginx-release/pipelines/envoy-nginx-release.yml
+++ b/envoy-nginx-release/pipelines/envoy-nginx-release.yml
@@ -27,13 +27,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-wats
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -50,6 +48,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -183,18 +186,13 @@ resources:
     days:
       - Thursday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -256,7 +254,7 @@ resources:
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
 
 - name: envoy-nginx-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -264,36 +262,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: envoy-nginx-release-env-lock
-
-- name: envoy-nginx-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: envoy-nginx-release-lock-export-release 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: envoy-nginx-release-lock-export-release
-
-- name: envoy-nginx-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: envoy-nginx-release-lock-prepare-env 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: envoy-nginx-release-lock-prepare-env
-
-- name: envoy-nginx-release-lock-wats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: envoy-nginx-release-lock-wats 
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: envoy-nginx-release-lock-wats
 
 - name: image
   type: registry-image
@@ -316,10 +284,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -518,18 +482,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: envoy-nginx-release-lock-prepare-env
+      - put: envoy-nginx-release-env-lock
         params:
-          release: envoy-nginx-release-lock-prepare-env
-      - put: envoy-nginx-release-lock-export-release
-        params:
-          release: envoy-nginx-release-lock-export-release
-      - put: envoy-nginx-release-lock-wats
-        params:
-          release: envoy-nginx-release-lock-wats
-  on_failure: *release-work-locks
+          release: envoy-nginx-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -541,21 +499,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: envoy-nginx-release-lock-prepare-env
-  - get: envoy-nginx-release-lock-export-release
-  - get: envoy-nginx-release-lock-wats
+    - get: envoy-nginx-release-env-lock
   - put: envoy-nginx-release-env-lock
     params:
       claim: envoy-nginx-release-env-lock
-  - put: envoy-nginx-release-lock-prepare-env
-    params:
-      claim: envoy-nginx-release-lock-prepare-env
-  - put: envoy-nginx-release-lock-export-release
-    params:
-      claim: envoy-nginx-release-lock-export-release
-  - put: envoy-nginx-release-lock-wats
-    params:
-      claim: envoy-nginx-release-lock-wats
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -573,12 +520,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: envoy-nginx-release-lock-prepare-env
-    params:
-      release: envoy-nginx-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -593,13 +536,7 @@ jobs:
       trigger: true
     - get: envoy-nginx-release-env-lock
       passed: [claim-env]
-    - get: envoy-nginx-release-lock-prepare-env
-      passed: [claim-env]
-    - get: envoy-nginx-release-lock-export-release
-      passed: [claim-env]
-    - get: envoy-nginx-release-lock-wats
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -700,10 +637,6 @@ jobs:
 
 - name: run-wats
   serial: true
-  ensure:
-    put: envoy-nginx-release-lock-wats
-    params:
-      release: envoy-nginx-release-lock-wats
   plan:
   - in_parallel:
     - get: ci
@@ -717,8 +650,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: envoy-nginx-release-lock-wats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -739,10 +670,6 @@ jobs:
 
 - name: export-release
   serial: true
-  ensure:
-    put: envoy-nginx-release-lock-export-release
-    params:
-      release: envoy-nginx-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -754,8 +681,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: envoy-nginx-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -883,34 +808,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: envoy-nginx-release-env-lock
-  - get: envoy-nginx-release-lock-prepare-env
-  - get: envoy-nginx-release-lock-export-release
-  - get: envoy-nginx-release-lock-wats
-  - put: check-lock-prepare-env
-    resource: envoy-nginx-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: envoy-nginx-release-env-lock
     params:
-      check: envoy-nginx-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: envoy-nginx-release-lock-export-release
-    params:
-      check: envoy-nginx-release-lock-export-release
-      retry-delay: 10m
-  - put: check-lock-wats
-    resource: envoy-nginx-release-lock-wats
-    params:
-      check: envoy-nginx-release-lock-wats
-      retry-delay: 10m
+      check_unclaimed: envoy-nginx-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: envoy-nginx-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 4h
 
 - name: cleanup-env
   serial: true
@@ -923,81 +851,44 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: envoy-nginx-release-env-lock
-        passed: [ check-work-locks ]
-      - get: envoy-nginx-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: envoy-nginx-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: envoy-nginx-release-lock-wats
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-envoy-nginx-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-envoy-nginx-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: envoy-nginx-release-env-lock
-        params:
-          release: envoy-nginx-release-env-lock 
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: envoy-nginx-release-lock-prepare-env
-  - put: envoy-nginx-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: envoy-nginx-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: envoy-nginx-release-lock-export-release
-  - put: envoy-nginx-release-lock-export-release
-    params:
-      release: envoy-nginx-release-lock-export-release
-
-- name: release-work-lock-wats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: envoy-nginx-release-lock-wats
-  - put: envoy-nginx-release-lock-wats
-    params:
-      release: envoy-nginx-release-lock-wats
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-envoy-nginx-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
   - get: envoy-nginx-release-env-lock
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - put: envoy-nginx-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: envoy-nginx-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-envoy-nginx-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/garden-runc-release/pipelines/garden-runc-release.yml
+++ b/garden-runc-release/pipelines/garden-runc-release.yml
@@ -34,19 +34,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-export-release
-  - release-work-lock-gats-with-containerd
-  - release-work-lock-gats-with-containerd-cgroupsv2
-  - release-work-lock-gats-with-cpu-throttling
-  - release-work-lock-gats-with-runc
-  - release-work-lock-gatsw
-  - release-work-lock-prepare-env
-  - release-work-lock-standalone-gdn-gats
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -64,6 +56,7 @@ resource_types:
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/frodenas/gcs-resource
     username: _json_key
     password: ((gcp-wg-arp-service-account/config-json))
+
 - name: command-runner
   type: docker-image
   source:
@@ -71,11 +64,17 @@ resource_types:
     username: _json_key
     password: ((gcp-wg-arp-service-account/config-json))
     tag: latest
+
 - name: slack-notification
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -274,18 +273,13 @@ resources:
     days:
       - Thursday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -377,7 +371,7 @@ resources:
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
 
 - name: garden-runc-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -385,96 +379,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: garden-runc-release-env-lock
-
-- name: garden-runc-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-prepare-env
-
-- name: garden-runc-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-export-release
-
-- name: garden-runc-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-cats
-
-- name: garden-runc-release-lock-gats-with-containerd
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-gats-with-containerd
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-gats-with-containerd
-
-- name: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-
-- name: garden-runc-release-lock-gats-with-cpu-throttling
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-gats-with-cpu-throttling
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-gats-with-cpu-throttling
-
-- name: garden-runc-release-lock-gats-with-runc
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-gats-with-runc
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-gats-with-runc
-
-- name: garden-runc-release-lock-gatsw
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-gatsw
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-gatsw
-
-- name: garden-runc-release-lock-standalone-gdn-gats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: garden-runc-release-lock-standalone-gdn-gats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: garden-runc-release-lock-standalone-gdn-gats
 
 - name: image
   type: registry-image
@@ -643,10 +547,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -1361,37 +1261,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
-    in_parallel:
-      steps:
-      - put: garden-runc-release-lock-prepare-env
+  on_abort: &release-env-lock
+    do:
+      - put: garden-runc-release-env-lock
         params:
-          release: garden-runc-release-lock-prepare-env
-      - put: garden-runc-release-lock-cats
-        params:
-          release: garden-runc-release-lock-cats
-      - put: garden-runc-release-lock-gats-with-containerd
-        params:
-          release: garden-runc-release-lock-gats-with-containerd
-      - put: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-        params:
-          release: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-      - put: garden-runc-release-lock-gats-with-cpu-throttling
-        params:
-          release: garden-runc-release-lock-gats-with-cpu-throttling
-      - put: garden-runc-release-lock-gats-with-runc
-        params:
-          release: garden-runc-release-lock-gats-with-runc
-      - put: garden-runc-release-lock-gatsw
-        params:
-          release: garden-runc-release-lock-gatsw
-      - put: garden-runc-release-lock-standalone-gdn-gats
-        params:
-          release: garden-runc-release-lock-standalone-gdn-gats
-      - put: garden-runc-release-lock-export-release
-        params:
-          release: garden-runc-release-lock-export-release
-  on_failure: *release-work-locks
+          release: garden-runc-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -1403,45 +1278,10 @@ jobs:
     - get: manual-release-trigger
       trigger: true
       passed: [ manual-release-trigger ]
-  - get: garden-runc-release-lock-prepare-env
-  - get: garden-runc-release-lock-cats
-  - get: garden-runc-release-lock-gats-with-containerd
-  - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-  - get: garden-runc-release-lock-gats-with-cpu-throttling
-  - get: garden-runc-release-lock-gats-with-runc
-  - get: garden-runc-release-lock-gatsw
-  - get: garden-runc-release-lock-standalone-gdn-gats
-  - get: garden-runc-release-lock-export-release
+    - get: garden-runc-release-env-lock
   - put: garden-runc-release-env-lock
     params:
       claim: garden-runc-release-env-lock
-  - put: garden-runc-release-lock-prepare-env
-    params:
-      claim: garden-runc-release-lock-prepare-env
-  - put: garden-runc-release-lock-cats
-    params:
-      claim: garden-runc-release-lock-cats
-  - put: garden-runc-release-lock-gats-with-containerd
-    params:
-      claim: garden-runc-release-lock-gats-with-containerd
-  - put: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-    params:
-      claim: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-  - put: garden-runc-release-lock-gats-with-cpu-throttling
-    params:
-      claim: garden-runc-release-lock-gats-with-cpu-throttling
-  - put: garden-runc-release-lock-gats-with-runc
-    params:
-      claim: garden-runc-release-lock-gats-with-runc
-  - put: garden-runc-release-lock-gatsw
-    params:
-      claim: garden-runc-release-lock-gatsw
-  - put: garden-runc-release-lock-standalone-gdn-gats
-    params:
-      claim: garden-runc-release-lock-standalone-gdn-gats
-  - put: garden-runc-release-lock-export-release
-    params:
-      claim: garden-runc-release-lock-export-release
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -1459,12 +1299,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: garden-runc-release-lock-prepare-env
-    params:
-      release: garden-runc-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -1477,23 +1313,7 @@ jobs:
     - get: env
       passed: [ claim-env ]
       trigger: true
-    - get: garden-runc-release-lock-prepare-env 
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-cats
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-gats-with-containerd
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-gats-with-cpu-throttling
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-gats-with-runc
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-gatsw
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-standalone-gdn-gats
-      passed: [ claim-env ]
-    - get: garden-runc-release-lock-export-release
+    - get: garden-runc-release-env-lock
       passed: [ claim-env ]
   - task: prepare-cf-deployment-env
     image: image
@@ -1586,10 +1406,6 @@ jobs:
 
 - name: run-cats
   serial: true
-  ensure:
-    put: garden-runc-release-lock-cats
-    params:
-      release: garden-runc-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -1603,8 +1419,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: garden-runc-release-lock-cats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1623,10 +1437,6 @@ jobs:
 
 - name: run-standalone-gdn-gats
   serial: true
-  ensure:
-    put: garden-runc-release-lock-standalone-gdn-gats
-    params:
-      release: garden-runc-release-lock-standalone-gdn-gats
   plan:
   - in_parallel:
     - get: ci
@@ -1642,8 +1452,6 @@ jobs:
     - get: garden-runc-release-rootfs
       params:
         format: rootfs
-    - get: garden-runc-release-lock-standalone-gdn-gats
-      passed: [ prepare-env ]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -1701,10 +1509,6 @@ jobs:
 - name: run-gatsw
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: garden-runc-release-lock-gatsw
-    params:
-      release: garden-runc-release-lock-gatsw
   plan:
   - in_parallel:
     - get: ci
@@ -1721,7 +1525,6 @@ jobs:
     - get: winc-release
     - get: windows-utilities-release
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-gatsw
   - task: upload-windows-stemcell
     file: ci/shared/tasks/bosh-upload-stemcell/linux.yml
     image: image
@@ -1754,10 +1557,6 @@ jobs:
       ERRAND_NAME: gats
 
 - name: run-gats-with-cpu-throttling
-  ensure:
-    put: garden-runc-release-lock-gats-with-cpu-throttling
-    params:
-      release: garden-runc-release-lock-gats-with-cpu-throttling
   serial: true
   serial_groups: [ acceptance ]
   plan:
@@ -1774,8 +1573,6 @@ jobs:
       resource: golang-release-latest
     - get: garden-ci-artifacts-release
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-gats-with-cpu-throttling
-      passed: [ prepare-env ]
   - task: bosh-deploy-gats
     image: image
     file: ci/shared/tasks/bosh-deploy-manifest/linux.yml
@@ -1799,10 +1596,6 @@ jobs:
 - name: run-gats-with-runc
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: garden-runc-release-lock-gats-with-runc
-    params:
-      release: garden-runc-release-lock-gats-with-runc
   plan:
   - in_parallel:
     - get: ci
@@ -1817,8 +1610,6 @@ jobs:
       resource: golang-release-latest
     - get: garden-ci-artifacts-release
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-gats-with-runc
-      passed: [ prepare-env ]
   - task: bosh-deploy-gats
     image: image
     file: ci/shared/tasks/bosh-deploy-manifest/linux.yml
@@ -1850,10 +1641,6 @@ jobs:
 - name: run-gats-with-containerd
   serial: true
   serial_groups: [ acceptance ]
-  ensure:
-    put: garden-runc-release-lock-gats-with-containerd
-    params:
-      release: garden-runc-release-lock-gats-with-containerd
   plan:
   - in_parallel:
     - get: ci
@@ -1868,8 +1655,6 @@ jobs:
       resource: golang-release-latest
     - get: garden-ci-artifacts-release
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-gats-with-containerd
-      passed: [ prepare-env ]
   - task: bosh-deploy-gats
     image: image
     file: ci/shared/tasks/bosh-deploy-manifest/linux.yml
@@ -1903,10 +1688,6 @@ jobs:
 - name: run-gats-with-containerd-cgroupsv2
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-    params:
-      release: garden-runc-release-lock-gats-with-containerd-cgroupsv2
   plan:
   - in_parallel:
     - get: ci
@@ -1921,7 +1702,6 @@ jobs:
       resource: golang-release-latest
     - get: garden-ci-artifacts-release
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
   - task: upload-noble-stemcell
     file: ci/shared/tasks/bosh-upload-stemcell/linux.yml
     image: image
@@ -1961,10 +1741,6 @@ jobs:
 
 - name: export-release
   serial: true
-  ensure:
-    put: garden-runc-release-lock-export-release
-    params:
-      release: garden-runc-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1976,7 +1752,6 @@ jobs:
       passed: [ prepare-env ]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: garden-runc-release-lock-export-release
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -2132,72 +1907,69 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: garden-runc-release-env-lock
-  - get: garden-runc-release-lock-prepare-env
-  - get: garden-runc-release-lock-cats
-  - get: garden-runc-release-lock-gats-with-containerd
-  - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-  - get: garden-runc-release-lock-gats-with-cpu-throttling
-  - get: garden-runc-release-lock-gats-with-runc
-  - get: garden-runc-release-lock-gatsw
-  - get: garden-runc-release-lock-standalone-gdn-gats
-  - get: garden-runc-release-lock-export-release
-  - put: check-lock-prepare-env
-    resource: garden-runc-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: garden-runc-release-env-lock
     params:
-      check: garden-runc-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: garden-runc-release-lock-cats
-    params:
-      check: garden-runc-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-gats-with-containerd
-    resource: garden-runc-release-lock-gats-with-containerd
-    params:
-      check: garden-runc-release-lock-gats-with-containerd
-      retry-delay: 10m
-  - put: check-lock-gats-with-containerd-cgroupsv2
-    resource: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-    params:
-      check: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-      retry-delay: 10m
-  - put: check-lock-gats-with-cpu-throttling
-    resource: garden-runc-release-lock-gats-with-cpu-throttling
-    params:
-      check: garden-runc-release-lock-gats-with-cpu-throttling
-      retry-delay: 10m
-  - put: check-lock-gats-with-runc
-    resource: garden-runc-release-lock-gats-with-runc
-    params:
-      check: garden-runc-release-lock-gats-with-runc
-      retry-delay: 10m
-  - put: check-lock-gatsw
-    resource: garden-runc-release-lock-gatsw
-    params:
-      check: garden-runc-release-lock-gatsw
-      retry-delay: 10m
-  - put: check-lock-standalone-gdn-gats
-    resource: garden-runc-release-lock-standalone-gdn-gats
-    params:
-      check: garden-runc-release-lock-standalone-gdn-gats
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: garden-runc-release-lock-export-release
-    params:
-      check: garden-runc-release-lock-export-release
-      retry-delay: 10m
+      check_unclaimed: garden-runc-release-env-lock
+      retry-delay: 60m
 
-- name: cleanup-env
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: garden-runc-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 5h
+
+  - try:
+      do:
+      - task: bosh-deld
+        image: image
+        file: ci/shared/tasks/bosh-deld/linux.yml
+        params:
+          BBL_STATE_DIR: bbl-garden-env
+          DEPLOYMENT_NAME: example-app
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
+    params:
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-garden-env
+      SUSPEND: false
+  - try:
+      do:
+      - put: garden-runc-release-env-lock
+        params:
+          release: garden-runc-release-env-lock
+
+- name: release-env-lock
+  plan:
+  - get: garden-runc-release-env-lock
+  - put: garden-runc-release-env-lock
+    params:
+      release: garden-runc-release-env-lock
+
+- name: force-cleanup-env
   serial: true
   plan:
   - in_parallel:
@@ -2205,32 +1977,6 @@ jobs:
       - get: ci
       - get: env
       - get: image
-      - get: manual-cleanup-trigger
-        trigger: true
-        passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-env-lock
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-cats
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-gats-with-containerd
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-gats-with-cpu-throttling
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-gats-with-runc
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-gatsw
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-standalone-gdn-gats
-        passed: [ check-work-locks ]
-      - get: garden-runc-release-lock-export-release
-        passed: [ check-work-locks ]
   - try:
       do:
       - task: bosh-deld
@@ -2271,122 +2017,85 @@ jobs:
         params:
           BBL_STATE_DIR: bbl-garden-env
           DEPLOYMENT_NAME: gats-with-cpu-throttling
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
+    params:
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-garden-env
+      SUSPEND: false
+
+- name: cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+      - get: manual-cleanup-trigger
+        trigger: true
+        passed: [ manual-cleanup-trigger ]
+      - get: garden-runc-release-env-lock
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
   - try:
       do:
-      - task: stop-bbl-envs
+      - task: bosh-deld
         image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
+        file: ci/shared/tasks/bosh-deld/linux.yml
         params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
           BBL_STATE_DIR: bbl-garden-env
-          SUSPEND: false
+          DEPLOYMENT_NAME: cf
+  - try:
+      do:
+      - task: bosh-deld
+        image: image
+        file: ci/shared/tasks/bosh-deld/linux.yml
+        params:
+          BBL_STATE_DIR: bbl-garden-env
+          DEPLOYMENT_NAME: gatsw
+  - try:
+      do:
+      - task: bosh-deld
+        image: image
+        file: ci/shared/tasks/bosh-deld/linux.yml
+        params:
+          BBL_STATE_DIR: bbl-garden-env
+          DEPLOYMENT_NAME: gats-with-runc
+  - try:
+      do:
+      - task: bosh-deld
+        image: image
+        file: ci/shared/tasks/bosh-deld/linux.yml
+        params:
+          BBL_STATE_DIR: bbl-garden-env
+          DEPLOYMENT_NAME: gats-with-containerd
+  - try:
+      do:
+      - task: bosh-deld
+        image: image
+        file: ci/shared/tasks/bosh-deld/linux.yml
+        params:
+          BBL_STATE_DIR: bbl-garden-env
+          DEPLOYMENT_NAME: gats-with-cpu-throttling
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
+    params:
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-garden-env
+      SUSPEND: false
   - try:
       do:
       - put: garden-runc-release-env-lock
         params:
           release: garden-runc-release-env-lock 
 
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-prepare-env
-  - put: garden-runc-release-lock-prepare-env
-    params:
-      release: garden-runc-release-lock-prepare-env
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-cats
-  - put: garden-runc-release-lock-cats
-    params:
-      release: garden-runc-release-lock-cats
-
-- name: release-work-lock-gats-with-containerd
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-gats-with-containerd
-  - put: garden-runc-release-lock-gats-with-containerd
-    params:
-      release: garden-runc-release-lock-gats-with-containerd
-
-- name: release-work-lock-gats-with-containerd-cgroupsv2
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-  - put: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-    params:
-      release: garden-runc-release-lock-gats-with-containerd-cgroupsv2
-
-- name: release-work-lock-gats-with-cpu-throttling
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-gats-with-cpu-throttling
-  - put: garden-runc-release-lock-gats-with-cpu-throttling
-    params:
-      release: garden-runc-release-lock-gats-with-cpu-throttling
-
-- name: release-work-lock-gats-with-runc
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-gats-with-runc
-  - put: garden-runc-release-lock-gats-with-runc
-    params:
-      release: garden-runc-release-lock-gats-with-runc
-
-- name: release-work-lock-gatsw
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-gatsw
-  - put: garden-runc-release-lock-gatsw
-    params:
-      release: garden-runc-release-lock-gatsw
-
-- name: release-work-lock-standalone-gdn-gats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-standalone-gdn-gats
-  - put: garden-runc-release-lock-standalone-gdn-gats
-    params:
-      release: garden-runc-release-lock-standalone-gdn-gats
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-lock-export-release
-  - put: garden-runc-release-lock-export-release
-    params:
-      release: garden-runc-release-lock-export-release
-
-- name: release-env-lock
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: garden-runc-release-env-lock
-  - put: garden-runc-release-env-lock
-    params:
-      release: garden-runc-release-env-lock 
 
 #! versioning
 - name: patch-bump

--- a/healthchecker-release/pipelines/healthchecker-release.yml
+++ b/healthchecker-release/pipelines/healthchecker-release.yml
@@ -25,12 +25,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -47,6 +46,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -149,18 +153,13 @@ resources:
     days:
       - Friday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -221,7 +220,7 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: healthchecker-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -229,26 +228,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: healthchecker-release-env-lock 
-
-- name: healthchecker-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: healthchecker-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: healthchecker-release-lock-prepare-env
-
-- name: healthchecker-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: healthchecker-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: healthchecker-release-lock-export-release
 
 - name: image
   type: registry-image
@@ -269,10 +248,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -426,15 +401,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: healthchecker-release-lock-prepare-env
+      - put: healthchecker-release-env-lock
         params:
-          release: healthchecker-release-lock-prepare-env
-      - put: healthchecker-release-lock-export-release
-        params:
-          release: healthchecker-release-lock-export-release
-  on_failure: *release-work-locks
+          release: healthchecker-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -446,18 +418,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: healthchecker-release-env-lock
-  - get: healthchecker-release-lock-prepare-env
-  - get: healthchecker-release-lock-export-release
+    - get: healthchecker-release-env-lock
   - put: healthchecker-release-env-lock
     params:
       claim: healthchecker-release-env-lock
-  - put: healthchecker-release-lock-prepare-env
-    params:
-      claim: healthchecker-release-lock-prepare-env
-  - put: healthchecker-release-lock-export-release
-    params:
-      claim: healthchecker-release-lock-export-release
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -476,12 +440,8 @@ jobs:
 - name: prepare-env
   serial: true
   serial_groups: [acceptance]
-  on_success:
-    put: healthchecker-release-lock-prepare-env
-    params:
-      release: healthchecker-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -493,7 +453,7 @@ jobs:
       passed: [claim-env]
       trigger: true
     - get: bpm
-  - try:
+  - try: &delete-ea-deployment
       do:
         - task: bosh-deld
           image: image
@@ -531,10 +491,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: healthchecker-release-lock-export-release
-    params:
-      release: healthchecker-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -545,8 +501,6 @@ jobs:
     - get: env
       passed: [prepare-env]
       trigger: true
-    - get: healthchecker-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -666,28 +620,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: healthchecker-release-env-lock
-  - get: healthchecker-release-lock-prepare-env
-  - get: healthchecker-release-lock-export-release
-  - put: check-lock-prepare-env
-    resource: healthchecker-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: healthchecker-release-env-lock
     params:
-      check: healthchecker-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: healthchecker-release-lock-export-release
-    params:
-      check: healthchecker-release-lock-export-release
-      retry-delay: 10m
+      check_unclaimed: healthchecker-release-env-lock
+      retry-delay: 15m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: healthchecker-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 30m
 
 - name: cleanup-env
   serial: true
@@ -700,69 +663,44 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: healthchecker-release-env-lock
-        passed: [ check-work-locks ]
-      - get: healthchecker-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: healthchecker-release-lock-export-release
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-hlthchk-env
-          DEPLOYMENT_NAME: example-app
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-hlthchk-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: healthchecker-release-env-lock
-        params:
-          release: healthchecker-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: healthchecker-release-lock-prepare-env
-  - put: healthchecker-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-ea-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: healthchecker-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: healthchecker-release-lock-export-release
-  - put: healthchecker-release-lock-export-release
-    params:
-      release: healthchecker-release-lock-export-release
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-hlthchk-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: healthchecker-release-env-lock
-  - put: healthchecker-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-ea-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: healthchecker-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-hlthchk-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/nats-release/pipelines/nats-release.yml
+++ b/nats-release/pipelines/nats-release.yml
@@ -28,13 +28,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -51,6 +49,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -174,18 +177,13 @@ resources:
     days:
       - Monday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -246,7 +244,7 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: nats-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -254,36 +252,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: nats-release-env-lock
-
-- name: nats-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nats-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nats-release-lock-prepare-env
-
-- name: nats-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nats-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nats-release-lock-cats
-
-- name: nats-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nats-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nats-release-lock-export-release
 
 - name: image
   type: registry-image
@@ -307,10 +275,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -517,18 +481,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: nats-release-lock-prepare-env
+      - put: nats-release-env-lock
         params:
-          release: nats-release-lock-prepare-env
-      - put: nats-release-lock-cats
-        params:
-          release: nats-release-lock-cats
-      - put: nats-release-lock-export-release
-        params:
-          release: nats-release-lock-export-release
-  on_failure: *release-work-locks
+          release: nats-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -540,22 +498,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: nats-release-env-lock
-  - get: nats-release-lock-prepare-env
-  - get: nats-release-lock-cats
-  - get: nats-release-lock-export-release
+    - get: nats-release-env-lock
   - put: nats-release-env-lock
     params:
       claim: nats-release-env-lock
-  - put: nats-release-lock-prepare-env
-    params:
-      claim: nats-release-lock-prepare-env
-  - put: nats-release-lock-cats
-    params:
-      claim: nats-release-lock-cats
-  - put: nats-release-lock-export-release
-    params:
-      claim: nats-release-lock-export-release
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -573,12 +519,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: nats-release-lock-prepare-env
-    params:
-      release: nats-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -592,13 +534,7 @@ jobs:
       passed: [ claim-env ]
     - get: nats-release-env-lock
       passed: [ claim-env ]
-    - get: nats-release-lock-prepare-env
-      passed: [ claim-env ]
-    - get: nats-release-lock-cats
-      passed: [ claim-env ]
-    - get: nats-release-lock-export-release
-      passed: [ claim-env ]
-  - try:
+  - try: &delete-cf-deployment
       do:
       - task: bosh-deld
         image: image
@@ -693,10 +629,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nats-release-lock-cats
-    params:
-      release: nats-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -710,8 +642,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: nats-release-lock-cats
-      passed: [ prepare-env ]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -734,10 +664,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nats-release-lock-export-release
-    params:
-      release: nats-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -749,8 +675,6 @@ jobs:
       passed: [ prepare-env ]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: nats-release-lock-export-release
-      passed: [ prepare-env ]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -890,121 +814,87 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: nats-release-env-lock
-  - get: nats-release-lock-prepare-env
-  - get: nats-release-lock-cats
-  - get: nats-release-lock-export-release
-  - put: check-lock-prepare-env
-    resource: nats-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: nats-release-env-lock
     params:
-      check: nats-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: nats-release-lock-cats
-    params:
-      check: nats-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: nats-release-lock-export-release
-    params:
-      check: nats-release-lock-export-release
-      retry-delay: 10m
+      check_unclaimed: nats-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: nats-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 3h
 
 - name: cleanup-env
   serial: true
   plan:
   - in_parallel:
       steps:
-        - get: ci
-        - get: env
-        - get: image
-        - get: manual-cleanup-trigger
-          trigger: true
-          passed: [ manual-cleanup-trigger ]
-        - get: lock-check-timer
-          trigger: true
-          passed: [ check-work-locks ]
-        - get: nats-release-env-lock
-          passed: [ check-work-locks ]
-        - get: nats-release-lock-prepare-env
-          passed: [ check-work-locks ]
-        - get: nats-release-lock-cats
-          passed: [ check-work-locks ]
-        - get: nats-release-lock-export-release
-          passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-nats-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-nats-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: nats-release-env-lock
-        params:
-          release: nats-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nats-release-lock-prepare-env
-  - put: nats-release-lock-prepare-env
+      - get: ci
+      - get: env
+      - get: image
+      - get: manual-cleanup-trigger
+        trigger: true
+        passed: [ manual-cleanup-trigger ]
+      - get: nats-release-env-lock
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: nats-release-lock-prepare-env
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nats-release-lock-cats
-  - put: nats-release-lock-cats
-    params:
-      release: nats-release-lock-cats
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nats-release-lock-export-release
-  - put: nats-release-lock-export-release
-    params:
-      release: nats-release-lock-export-release
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-nats-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: nats-release-env-lock
-  - put: nats-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: nats-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-nats-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/nfs-volume-release/pipelines/nfs-volume-release.yml
+++ b/nfs-volume-release/pipelines/nfs-volume-release.yml
@@ -31,16 +31,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-dockerdriver-integration
-  - release-work-lock-export-release
-  - release-work-lock-map-fs-performance-acceptance
-  - release-work-lock-prepare-env
-  - release-work-lock-volume-service-acceptance
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -49,7 +44,6 @@ groups:
   - minor-bump
   - patch-bump
 
-
 #! Define-ResourceGroups
 resource_types:
 - name: slack-notification
@@ -57,6 +51,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -198,18 +197,13 @@ resources:
     days:
       - Tuesday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -261,7 +255,7 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: nfs-volume-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -269,66 +263,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: nfs-volume-release-env-lock 
-
-- name: nfs-volume-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-prepare-env
-
-- name: nfs-volume-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-export-release
-
-- name: nfs-volume-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-cats
-
-- name: nfs-volume-release-lock-dockerdriver-integration
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-dockerdriver-integration
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-dockerdriver-integration
-
-- name: nfs-volume-release-lock-volume-service-acceptance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-volume-service-acceptance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-volume-service-acceptance
-
-- name: nfs-volume-release-lock-map-fs-performance-acceptance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: nfs-volume-release-lock-map-fs-performance-acceptance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: nfs-volume-release-lock-map-fs-performance-acceptance
 
 - name: image
   type: registry-image
@@ -426,10 +360,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -788,27 +718,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: nfs-volume-release-lock-prepare-env
+      - put: nfs-volume-release-env-lock
         params:
-          release: nfs-volume-release-lock-prepare-env
-      - put: nfs-volume-release-lock-export-release
-        params:
-          release: nfs-volume-release-lock-export-release
-      - put: nfs-volume-release-lock-cats
-        params:
-          release: nfs-volume-release-lock-cats
-      - put: nfs-volume-release-lock-dockerdriver-integration
-        params:
-          release: nfs-volume-release-lock-dockerdriver-integration
-      - put: nfs-volume-release-lock-volume-service-acceptance
-        params:
-          release: nfs-volume-release-lock-volume-service-acceptance
-      - put: nfs-volume-release-lock-map-fs-performance-acceptance
-        params:
-          release: nfs-volume-release-lock-map-fs-performance-acceptance
-  on_failure: *release-work-locks
+          release: nfs-volume-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -820,34 +735,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: nfs-volume-release-env-lock
-  - get: nfs-volume-release-lock-prepare-env
-  - get: nfs-volume-release-lock-export-release
-  - get: nfs-volume-release-lock-cats
-  - get: nfs-volume-release-lock-dockerdriver-integration
-  - get: nfs-volume-release-lock-volume-service-acceptance
-  - get: nfs-volume-release-lock-map-fs-performance-acceptance
+    - get: nfs-volume-release-env-lock
   - put: nfs-volume-release-env-lock
     params:
       claim: nfs-volume-release-env-lock
-  - put: nfs-volume-release-lock-prepare-env
-    params:
-      claim: nfs-volume-release-lock-prepare-env
-  - put: nfs-volume-release-lock-export-release
-    params:
-      claim: nfs-volume-release-lock-export-release
-  - put: nfs-volume-release-lock-cats
-    params:
-      claim: nfs-volume-release-lock-cats
-  - put: nfs-volume-release-lock-dockerdriver-integration
-    params:
-      claim: nfs-volume-release-lock-dockerdriver-integration
-  - put: nfs-volume-release-lock-volume-service-acceptance
-    params:
-      claim: nfs-volume-release-lock-volume-service-acceptance
-  - put: nfs-volume-release-lock-map-fs-performance-acceptance
-    params:
-      claim: nfs-volume-release-lock-map-fs-performance-acceptance
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -866,12 +757,8 @@ jobs:
 - name: prepare-env
   serial: true
   serial_groups: [acceptance]
-  on_success:
-    put: nfs-volume-release-lock-prepare-env
-    params:
-      release: nfs-volume-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -886,19 +773,7 @@ jobs:
       trigger: true
     - get: nfs-volume-release-env-lock
       passed: [claim-env]
-    - get: nfs-volume-release-lock-prepare-env
-      passed: [claim-env]
-    - get: nfs-volume-release-lock-export-release
-      passed: [claim-env]
-    - get: nfs-volume-release-lock-cats
-      passed: [claim-env]
-    - get: nfs-volume-release-lock-dockerdriver-integration
-      passed: [claim-env]
-    - get: nfs-volume-release-lock-volume-service-acceptance
-      passed: [claim-env]
-    - get: nfs-volume-release-lock-map-fs-performance-acceptance
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1012,10 +887,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nfs-volume-release-lock-cats
-    params:
-      release: nfs-volume-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -1029,8 +900,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: nfs-volume-release-lock-cats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1057,10 +926,6 @@ jobs:
 - name: volume-services-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nfs-volume-release-lock-volume-service-acceptance
-    params:
-      release: nfs-volume-release-lock-volume-service-acceptance
   plan:
   - in_parallel:
       fail_fast: true
@@ -1076,8 +941,6 @@ jobs:
         trigger: true
       - get: package-release
         resource: golang-release-latest
-      - get: nfs-volume-release-lock-volume-service-acceptance
-        passed: [ prepare-env ]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -1091,12 +954,12 @@ jobs:
         output_mapping:
           built-acceptance-test-configs: configs-without-ldap
         params:
-          CONFIGS: volume-services-acceptance-tests
-          ENVS: |
-            VOLUME_SERVICE_SERVICE_NAME=nfs
-            VOLUME_SERVICE_BROKER_NAME=nfsbroker
-            VOLUME_SERVICE_PLAN_NAME=Existing
-          BBL_STATE_DIR: bbl-nfs-volume-env
+          configs: volume-services-acceptance-tests
+          envs: |
+            volume_service_service_name=nfs
+            volume_service_broker_name=nfsbroker
+            volume_service_plan_name=existing
+          bbl_state_dir: bbl-nfs-volume-env
       - task: run-bin-test-cf-volume-services-acceptance-tests-without-ldap
         file: ci/shared/tasks/run-bin-test/linux.yml
         input_mapping:
@@ -1108,8 +971,8 @@ jobs:
           image_password: ((gcp-wg-arp-service-account/config-json))
           image_tag: ((.:image_tag))
         params:
-          ENVS: |
-            CONFIG=$PWD/input-01/volume-services-acceptance-tests.json
+          envs: |
+            config=$pwd/input-01/volume-services-acceptance-tests.json
     - do: 
       - task: generate-cf-volume-services-acceptance-tests-config-with-ldap
         image: image
@@ -1117,13 +980,13 @@ jobs:
         output_mapping:
           built-acceptance-test-configs: configs-with-ldap
         params:
-          CONFIGS: volume-services-acceptance-tests
-          WITH_ISOSEG: true
-          ENVS: |
-            VOLUME_SERVICE_SERVICE_NAME=nfs
-            VOLUME_SERVICE_BROKER_NAME=nfsldapbroker
-            VOLUME_SERVICE_PLAN_NAME=Existing
-          BBL_STATE_DIR: bbl-nfs-volume-env
+          configs: volume-services-acceptance-tests
+          with_isoseg: true
+          envs: |
+            volume_service_service_name=nfs
+            volume_service_broker_name=nfsldapbroker
+            volume_service_plan_name=existing
+          bbl_state_dir: bbl-nfs-volume-env
       - task: run-bin-test-cf-volume-services-acceptance-tests-with-ldap
         file: ci/shared/tasks/run-bin-test/linux.yml
         input_mapping:
@@ -1141,10 +1004,6 @@ jobs:
 - name: dockerdriver-integration
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nfs-volume-release-lock-dockerdriver-integration
-    params:
-      release: nfs-volume-release-lock-dockerdriver-integration
   plan:
   - in_parallel:
       fail_fast: true
@@ -1158,8 +1017,6 @@ jobs:
         passed: [ prepare-env ]
         trigger: true
       - get: cf-deployment-concourse-tasks
-      - get: nfs-volume-release-lock-dockerdriver-integration
-        passed: [ prepare-env ]
   - task: run-dockerdriver-integration-errand
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -1172,10 +1029,6 @@ jobs:
 - name: map-fs-performance-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nfs-volume-release-lock-map-fs-performance-acceptance
-    params:
-      release: nfs-volume-release-lock-map-fs-performance-acceptance
   plan:
   - in_parallel:
       fail_fast: true
@@ -1189,8 +1042,6 @@ jobs:
         passed: [ prepare-env ]
         trigger: true
       - get: cf-deployment-concourse-tasks
-      - get: nfs-volume-release-lock-map-fs-performance-acceptance
-        passed: [ prepare-env ]
   - task: run-map-fs-performace-acceptance-tests-errand
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -1203,10 +1054,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: nfs-volume-release-lock-export-release
-    params:
-      release: nfs-volume-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1218,8 +1065,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: nfs-volume-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1345,169 +1190,87 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: nfs-volume-release-env-lock
-  - get: nfs-volume-release-lock-prepare-env
-  - get: nfs-volume-release-lock-export-release
-  - get: nfs-volume-release-lock-cats
-  - get: nfs-volume-release-lock-dockerdriver-integration
-  - get: nfs-volume-release-lock-volume-service-acceptance
-  - get: nfs-volume-release-lock-map-fs-performance-acceptance
-  - put: nfs-volume-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: nfs-volume-release-env-lock
     params:
-      check: nfs-volume-release-lock-prepare-env
-      retry-delay: 10m
-  - put: nfs-volume-release-lock-export-release
-    params:
-      check: nfs-volume-release-lock-export-release
-      retry-delay: 10m
-  - put: nfs-volume-release-lock-cats
-    params:
-      check: nfs-volume-release-lock-cats
-      retry-delay: 10m
-  - put: nfs-volume-release-lock-dockerdriver-integration
-    params:
-      check: nfs-volume-release-lock-dockerdriver-integration
-      retry-delay: 10m
-  - put: nfs-volume-release-lock-volume-service-acceptance
-    params:
-      check: nfs-volume-release-lock-volume-service-acceptance
-      retry-delay: 10m
-  - put: nfs-volume-release-lock-map-fs-performance-acceptance
-    params:
-      check: nfs-volume-release-lock-map-fs-performance-acceptance
-      retry-delay: 10m
+      check_unclaimed: nfs-volume-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: nfs-volume-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 3h
 
 - name: cleanup-env
   serial: true
   plan:
   - in_parallel:
       steps:
+      - get: ci
       - get: env
       - get: image
-      - get: ci
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: nfs-volume-release-env-lock
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-cats
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-dockerdriver-integration
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-volume-service-acceptance
-        passed: [ check-work-locks ]
-      - get: nfs-volume-release-lock-map-fs-performance-acceptance
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-nfs-volume-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-nfs-volume-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: nfs-volume-release-env-lock
-        params:
-          release: nfs-volume-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-prepare-env
-  - put: nfs-volume-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: nfs-volume-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-export-release
-  - put: nfs-volume-release-lock-export-release
-    params:
-      release: nfs-volume-release-lock-export-release
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-cats
-  - put: nfs-volume-release-lock-cats
-    params:
-      release: nfs-volume-release-lock-cats
-
-- name: release-work-lock-dockerdriver-integration
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-dockerdriver-integration
-  - put: nfs-volume-release-lock-dockerdriver-integration
-    params:
-      release: nfs-volume-release-lock-dockerdriver-integration
-
-- name: release-work-lock-volume-service-acceptance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-volume-service-acceptance
-  - put: nfs-volume-release-lock-volume-service-acceptance
-    params:
-      release: nfs-volume-release-lock-volume-service-acceptance
-
-- name: release-work-lock-map-fs-performance-acceptance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: nfs-volume-release-lock-map-fs-performance-acceptance
-  - put: nfs-volume-release-lock-map-fs-performance-acceptance
-    params:
-      release: nfs-volume-release-lock-map-fs-performance-acceptance
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-nfs-volume-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: nfs-volume-release-env-lock
-  - put: nfs-volume-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: nfs-volume-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-nfs-volume-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/routing-release/pipelines/routing-release.yml
+++ b/routing-release/pipelines/routing-release.yml
@@ -34,17 +34,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-cfsmoke
-  - release-work-lock-cipher-suite
-  - release-work-lock-drats
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-rats
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -63,6 +57,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 resources:
 #! REPOS
@@ -263,18 +262,13 @@ resources:
     days:
       - Monday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -346,7 +340,7 @@ resources:
     driver: gcs
 
 - name: routing-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -354,76 +348,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: routing-release-env-lock 
-
-- name: routing-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-cats
-
-- name: routing-release-lock-rats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-rats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-rats
-
-- name: routing-release-lock-drats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-drats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-drats
-
-- name: routing-release-lock-cfsmoke
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-cfsmoke
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-cfsmoke
-
-- name: routing-release-lock-cipher-suite
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-cipher-suite
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-cipher-suite
-
-- name: routing-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-prepare-env
-
-- name: routing-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: routing-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: routing-release-lock-export-release
 
 - name: image
   type: registry-image
@@ -453,10 +377,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -791,30 +711,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: routing-release-lock-prepare-env
+      - put: routing-release-env-lock
         params:
-          release: routing-release-lock-prepare-env
-      - put: routing-release-lock-cats
-        params:
-          release: routing-release-lock-cats
-      - put: routing-release-lock-rats
-        params:
-          release: routing-release-lock-rats
-      - put: routing-release-lock-drats
-        params:
-          release: routing-release-lock-drats
-      - put: routing-release-lock-cfsmoke
-        params:
-          release: routing-release-lock-cfsmoke
-      - put: routing-release-lock-cipher-suite
-        params:
-          release: routing-release-lock-cipher-suite
-      - put: routing-release-lock-export-release
-        params:
-          release: routing-release-lock-export-release
-  on_failure: *release-work-locks
+          release: routing-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -826,38 +728,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: routing-release-env-lock
-  - get: routing-release-lock-prepare-env
-  - get: routing-release-lock-cats
-  - get: routing-release-lock-rats
-  - get: routing-release-lock-drats
-  - get: routing-release-lock-cfsmoke
-  - get: routing-release-lock-cipher-suite
-  - get: routing-release-lock-export-release
+    - get: routing-release-env-lock
   - put: routing-release-env-lock
     params:
       claim: routing-release-env-lock
-  - put: routing-release-lock-prepare-env
-    params:
-      claim: routing-release-lock-prepare-env
-  - put: routing-release-lock-cats
-    params:
-      claim: routing-release-lock-cats
-  - put: routing-release-lock-rats
-    params:
-      claim: routing-release-lock-rats
-  - put: routing-release-lock-drats
-    params:
-      claim: routing-release-lock-drats
-  - put: routing-release-lock-cfsmoke
-    params:
-      claim: routing-release-lock-cfsmoke
-  - put: routing-release-lock-cipher-suite
-    params:
-      claim: routing-release-lock-cipher-suite
-  - put: routing-release-lock-export-release
-    params:
-      claim: routing-release-lock-export-release
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -875,12 +749,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: routing-release-lock-prepare-env
-    params:
-      release: routing-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -895,21 +765,7 @@ jobs:
       trigger: true
     - get: routing-release-env-lock
       passed: [claim-env]
-    - get: routing-release-lock-prepare-env
-      passed: [claim-env]
-    - get: routing-release-lock-cats
-      passed: [claim-env]
-    - get: routing-release-lock-rats
-      passed: [claim-env]
-    - get: routing-release-lock-drats
-      passed: [claim-env]
-    - get: routing-release-lock-cfsmoke
-      passed: [claim-env]
-    - get: routing-release-lock-cipher-suite
-      passed: [claim-env]
-    - get: routing-release-lock-export-release
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1012,10 +868,6 @@ jobs:
       ENABLED_FEATURE_FLAGS: diego_docker service_instance_sharing
 
 - name: run-cats
-  ensure:
-    put: routing-release-lock-cats
-    params:
-      release: routing-release-lock-cats
   serial: true
   serial_groups: [acceptance]
   plan:
@@ -1031,8 +883,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: routing-release-lock-cats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1052,10 +902,6 @@ jobs:
 - name: run-drats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: routing-release-lock-drats
-    params:
-      release: routing-release-lock-drats
   plan:
   - in_parallel:
     - get: ci
@@ -1069,8 +915,6 @@ jobs:
     - get: bbr-binary-release
     - get: disaster-recovery-acceptance-tests
     - get: cf-deployment
-    - get: routing-release-lock-drats
-      passed: [prepare-env]
   - task: create-drats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -1089,10 +933,6 @@ jobs:
 - name: run-rats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: routing-release-lock-rats
-    params:
-      release: routing-release-lock-rats
   plan:
   - in_parallel:
     - get: ci
@@ -1107,8 +947,6 @@ jobs:
       resource: golang-release-latest
     - get: cf-deployment
     - get: cf-deployment-concourse-tasks
-    - get: routing-release-lock-rats
-      passed: [prepare-env]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -1230,10 +1068,6 @@ jobs:
 - name: run-cfsmoke
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: routing-release-lock-cfsmoke
-    params:
-      release: routing-release-lock-cfsmoke
   plan:
   - in_parallel:
     - get: ci
@@ -1246,7 +1080,6 @@ jobs:
       trigger: true
     - get: cf-deployment-concourse-tasks
     - get: cf-smoke-tests-release
-    - get: routing-release-lock-cfsmoke
   - task: create-cfsmoke-config
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
     image: image
@@ -1266,10 +1099,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: routing-release-lock-export-release
-    params:
-      release: routing-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1281,8 +1110,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: routing-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1290,10 +1117,6 @@ jobs:
       BBL_STATE_DIR: bbl-routing-env
 
 - name: run-cipher-suite
-  ensure:
-    put: routing-release-lock-cipher-suite
-    params:
-      release: routing-release-lock-cipher-suite
   plan:
   - in_parallel:
     - get: ci
@@ -1308,9 +1131,7 @@ jobs:
     - get: cipher-test-release
       trigger: true
     - get: gcp-stemcell-bionic
-    - get: routing-release-lock-cipher-suite
-      passed: [prepare-env]
-  - try:
+  - try: &delete-cipher-deployment
       do:
         - task: bosh-deld
           image: image
@@ -1462,58 +1283,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: routing-release-env-lock
-  - get: routing-release-lock-prepare-env
-  - get: routing-release-lock-cats
-  - get: routing-release-lock-rats
-  - get: routing-release-lock-drats
-  - get: routing-release-lock-cfsmoke
-  - get: routing-release-lock-cipher-suite
-  - get: routing-release-lock-export-release
-  - put: check-lock-prepare-env
-    resource: routing-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: routing-release-env-lock
     params:
-      check: routing-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: routing-release-lock-cats
-    params:
-      check: routing-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-rats
-    resource: routing-release-lock-rats
-    params:
-      check: routing-release-lock-rats
-      retry-delay: 10m
-  - put: check-lock-drats
-    resource: routing-release-lock-drats
-    params:
-      check: routing-release-lock-drats
-      retry-delay: 10m
-  - put: check-lock-cfsmoke
-    resource: routing-release-lock-cfsmoke
-    params:
-      check: routing-release-lock-cfsmoke
-      retry-delay: 10m
-  - put: check-lock-cipher-suite
-    resource: routing-release-lock-cipher-suite
-    params:
-      check: routing-release-lock-cipher-suite
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: routing-release-lock-export-release
-    params:
-      check: routing-release-lock-export-release
-      retry-delay: 10m
+      check_unclaimed: routing-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: routing-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 5h
 
 - name: cleanup-env
   serial: true
@@ -1526,137 +1326,47 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: routing-release-env-lock
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-cats
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-rats
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-drats
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-cfsmoke
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-cipher-suite
-        passed: [ check-work-locks ]
-      - get: routing-release-lock-export-release
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-routing-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-routing-env
-          DEPLOYMENT_NAME: cipher
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-routing-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: routing-release-env-lock
-        params:
-          release: routing-release-env-lock 
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-prepare-env
-  - put: routing-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - try: *delete-cipher-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: routing-release-lock-prepare-env
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-cats
-  - put: routing-release-lock-cats
-    params:
-      release: routing-release-lock-cats
-
-- name: release-work-lock-rats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-rats
-  - put: routing-release-lock-rats
-    params:
-      release: routing-release-lock-rats
-
-- name: release-work-lock-drats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-drats
-  - put: routing-release-lock-drats
-    params:
-      release: routing-release-lock-drats
-
-- name: release-work-lock-cfsmoke
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-cfsmoke
-  - put: routing-release-lock-cfsmoke
-    params:
-      release: routing-release-lock-cfsmoke
-
-- name: release-work-lock-cipher-suite
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-cipher-suite
-  - put: routing-release-lock-cipher-suite
-    params:
-      release: routing-release-lock-cipher-suite
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: routing-release-lock-export-release
-  - put: routing-release-lock-export-release
-    params:
-      release: routing-release-lock-export-release
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-routing-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: routing-release-env-lock
-  - put: routing-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - try: *delete-cipher-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: routing-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-routing-env
+      SUSPEND: false
+
 
 #! versioning
 - name: patch-bump

--- a/smb-volume-release/pipelines/smb-volume-release.yml
+++ b/smb-volume-release/pipelines/smb-volume-release.yml
@@ -30,15 +30,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-cats
-  - release-work-lock-dockerdriver-integration
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-volume-service-acceptance
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -55,6 +51,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -196,18 +197,13 @@ resources:
     days:
       - Tuesday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -259,7 +255,7 @@ resources:
     json_key: ((gcp-wg-arp-oss-service-account/config-json))
 
 - name: smb-volume-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -267,56 +263,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: smb-volume-release-env-lock 
-
-- name: smb-volume-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: smb-volume-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: smb-volume-release-lock-prepare-env
-
-- name: smb-volume-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: smb-volume-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: smb-volume-release-lock-export-release
-
-- name: smb-volume-release-lock-cats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: smb-volume-release-lock-cats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: smb-volume-release-lock-cats
-
-- name: smb-volume-release-lock-dockerdriver-integration
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: smb-volume-release-lock-dockerdriver-integration
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: smb-volume-release-lock-dockerdriver-integration
-
-- name: smb-volume-release-lock-volume-service-acceptance
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: smb-volume-release-lock-volume-service-acceptance
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: smb-volume-release-lock-volume-service-acceptance
 
 - name: image
   type: registry-image
@@ -390,10 +336,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -705,24 +647,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: smb-volume-release-lock-prepare-env
+      - put: smb-volume-release-env-lock
         params:
-          release: smb-volume-release-lock-prepare-env
-      - put: smb-volume-release-lock-export-release
-        params:
-          release: smb-volume-release-lock-export-release
-      - put: smb-volume-release-lock-cats
-        params:
-          release: smb-volume-release-lock-cats
-      - put: smb-volume-release-lock-dockerdriver-integration
-        params:
-          release: smb-volume-release-lock-dockerdriver-integration
-      - put: smb-volume-release-lock-volume-service-acceptance
-        params:
-          release: smb-volume-release-lock-volume-service-acceptance
-  on_failure: *release-work-locks
+          release: smb-volume-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -734,30 +664,10 @@ jobs:
       passed: [ release-time-gate ]
     - get: image
     - get: env
-  - get: smb-volume-release-env-lock
-  - get: smb-volume-release-lock-prepare-env
-  - get: smb-volume-release-lock-export-release
-  - get: smb-volume-release-lock-cats
-  - get: smb-volume-release-lock-dockerdriver-integration
-  - get: smb-volume-release-lock-volume-service-acceptance
+    - get: smb-volume-release-env-lock
   - put: smb-volume-release-env-lock
     params:
       claim: smb-volume-release-env-lock
-  - put: smb-volume-release-lock-prepare-env
-    params:
-      claim: smb-volume-release-lock-prepare-env
-  - put: smb-volume-release-lock-export-release
-    params:
-      claim: smb-volume-release-lock-export-release
-  - put: smb-volume-release-lock-cats
-    params:
-      claim: smb-volume-release-lock-cats
-  - put: smb-volume-release-lock-dockerdriver-integration
-    params:
-      claim: smb-volume-release-lock-dockerdriver-integration
-  - put: smb-volume-release-lock-volume-service-acceptance
-    params:
-      claim: smb-volume-release-lock-volume-service-acceptance
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -776,12 +686,8 @@ jobs:
 - name: prepare-env
   serial: true
   serial_groups: [acceptance]
-  on_success:
-    put: smb-volume-release-lock-prepare-env
-    params:
-      release: smb-volume-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -796,17 +702,7 @@ jobs:
       trigger: true
     - get: smb-volume-release-env-lock
       passed: [claim-env]
-    - get: smb-volume-release-lock-prepare-env
-      passed: [claim-env]
-    - get: smb-volume-release-lock-export-release
-      passed: [claim-env]
-    - get: smb-volume-release-lock-cats
-      passed: [claim-env]
-    - get: smb-volume-release-lock-dockerdriver-integration
-      passed: [claim-env]
-    - get: smb-volume-release-lock-volume-service-acceptance
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -898,10 +794,6 @@ jobs:
 - name: run-cats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: smb-volume-release-lock-cats
-    params:
-      release: smb-volume-release-lock-cats
   plan:
   - in_parallel:
     - get: ci
@@ -915,8 +807,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: smb-volume-release-lock-cats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -943,10 +833,6 @@ jobs:
 - name: volume-services-acceptance-tests
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: smb-volume-release-lock-volume-service-acceptance
-    params:
-      release: smb-volume-release-lock-volume-service-acceptance
   plan:
   - in_parallel:
       fail_fast: true
@@ -962,8 +848,6 @@ jobs:
         trigger: true
       - get: package-release
         resource: golang-release-latest
-      - get: smb-volume-release-lock-volume-service-acceptance
-        passed: [ prepare-env ]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -998,10 +882,6 @@ jobs:
 - name: dockerdriver-integration
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: smb-volume-release-lock-dockerdriver-integration
-    params:
-      release: smb-volume-release-lock-dockerdriver-integration
   plan:
   - in_parallel:
       fail_fast: true
@@ -1015,8 +895,6 @@ jobs:
         passed: [ prepare-env ]
         trigger: true
       - get: cf-deployment-concourse-tasks
-      - get: smb-volume-release-lock-dockerdriver-integration
-        passed: [ prepare-env ]
   - task: run-dockerdriver-integration-errand
     file: cf-deployment-concourse-tasks/run-errand/task.yml
     input_mapping:
@@ -1029,10 +907,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: smb-volume-release-lock-export-release
-    params:
-      release: smb-volume-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1044,8 +918,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: smb-volume-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1171,157 +1043,87 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: smb-volume-release-env-lock
-  - get: smb-volume-release-lock-prepare-env
-  - get: smb-volume-release-lock-export-release
-  - get: smb-volume-release-lock-cats
-  - get: smb-volume-release-lock-dockerdriver-integration
-  - get: smb-volume-release-lock-volume-service-acceptance
-  - put: check-lock-prepare-env
-    resource: smb-volume-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: smb-volume-release-env-lock
     params:
-      check: smb-volume-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: smb-volume-release-lock-export-release
-    params:
-      check: smb-volume-release-lock-export-release
-      retry-delay: 10m
-  - put: check-lock-cats
-    resource: smb-volume-release-lock-cats
-    params:
-      check: smb-volume-release-lock-cats
-      retry-delay: 10m
-  - put: check-lock-dockerdriver-integration
-    resource: smb-volume-release-lock-dockerdriver-integration
-    params:
-      check: smb-volume-release-lock-dockerdriver-integration
-      retry-delay: 10m
-  - put: check-lock-volume-service-acceptance
-    resource: smb-volume-release-lock-volume-service-acceptance
-    params:
-      check: smb-volume-release-lock-volume-service-acceptance
-      retry-delay: 10m
+      check_unclaimed: smb-volume-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: smb-volume-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 3h
 
 - name: cleanup-env
   serial: true
   plan:
   - in_parallel:
       steps:
+      - get: ci
       - get: env
       - get: image
-      - get: ci
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: smb-volume-release-env-lock
-        passed: [ check-work-locks ]
-      - get: smb-volume-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: smb-volume-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: smb-volume-release-lock-cats
-        passed: [ check-work-locks ]
-      - get: smb-volume-release-lock-dockerdriver-integration
-        passed: [ check-work-locks ]
-      - get: smb-volume-release-lock-volume-service-acceptance
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-smb-volume-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-smb-volume-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: smb-volume-release-env-lock
-        params:
-          release: smb-volume-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: smb-volume-release-lock-prepare-env
-  - put: smb-volume-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: smb-volume-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: smb-volume-release-lock-export-release
-  - put: smb-volume-release-lock-export-release
-    params:
-      release: smb-volume-release-lock-export-release
-
-- name: release-work-lock-cats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: smb-volume-release-lock-cats
-  - put: smb-volume-release-lock-cats
-    params:
-      release: smb-volume-release-lock-cats
-
-- name: release-work-lock-dockerdriver-integration
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: smb-volume-release-lock-dockerdriver-integration
-  - put: smb-volume-release-lock-dockerdriver-integration
-    params:
-      release: smb-volume-release-lock-dockerdriver-integration
-
-- name: release-work-lock-volume-service-acceptance
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: smb-volume-release-lock-volume-service-acceptance
-  - put: smb-volume-release-lock-volume-service-acceptance
-    params:
-      release: smb-volume-release-lock-volume-service-acceptance
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-smb-volume-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: smb-volume-release-env-lock
-  - put: smb-volume-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: smb-volume-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-smb-volume-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/winc-release/pipelines/winc-release.yml
+++ b/winc-release/pipelines/winc-release.yml
@@ -29,14 +29,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-export-release
-  - release-work-lock-gatsw
-  - release-work-lock-prepare-env
-  - release-work-lock-wats
+  - force-cleanup-env
   - release-env-lock
 
 - name: version
@@ -54,6 +51,7 @@ resource_types:
     repository: us-central1-docker.pkg.dev/cf-diego-pivotal/tas-runtime-dockerhub-mirror/cloudfoundry/bosh-deployment-resource
     username: _json_key
     password: ((gcp-wg-arp-service-account/config-json))
+
 - name: cf-cli-resource
   type: registry-image
   source:
@@ -61,11 +59,17 @@ resource_types:
     username: _json_key
     password: ((gcp-wg-arp-service-account/config-json))
     tag: latest
+
 - name: slack-notification
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -173,6 +177,7 @@ resources:
     branch: main
     uri: git@github.com:cloudfoundry/diff-exporter.git
     private_key: ((github-appruntimeplatform-bot/private-key))
+
 - name: updated-go-mod-groot-windows
   type: git
   icon: source-branch
@@ -180,6 +185,7 @@ resources:
     branch: main
     uri: git@github.com:cloudfoundry/groot-windows.git
     private_key: ((github-appruntimeplatform-bot/private-key))
+
 - name: updated-go-mod-winc
   type: git
   icon: source-branch
@@ -187,6 +193,7 @@ resources:
     branch: main
     uri: git@github.com:cloudfoundry/winc.git
     private_key: ((github-appruntimeplatform-bot/private-key))
+
 - name: updated-go-mod-certsplitter
   type: git
   icon: source-branch
@@ -194,6 +201,7 @@ resources:
     branch: main
     uri: git@github.com:cloudfoundry/certsplitter.git
     private_key: ((github-appruntimeplatform-bot/private-key))
+
 - name: updated-go-mod-cert-injector
   type: git
   icon: source-branch
@@ -254,18 +262,13 @@ resources:
     days:
       - Thursday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -279,7 +282,6 @@ resources:
   type: slack-notification
   source:
     url: ((slack-ci-channel/webhook))
-
 
 - name: github-release
   type: github-release
@@ -311,7 +313,7 @@ resources:
     region_name: us-east-1
 
 - name: winc-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -319,46 +321,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: winc-release-env-lock
-
-- name: winc-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: winc-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: winc-release-lock-prepare-env
-
-- name: winc-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: winc-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: winc-release-lock-export-release
-
-- name: winc-release-lock-wats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: winc-release-lock-wats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: winc-release-lock-wats
-
-- name: winc-release-lock-gatsw
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: winc-release-lock-gatsw
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: winc-release-lock-gatsw
 
 - name: windows-worker-lock
   type: pool
@@ -418,10 +380,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -729,21 +687,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: winc-release-lock-prepare-env
+      - put: winc-release-env-lock
         params:
-          release: winc-release-lock-prepare-env
-      - put: winc-release-lock-export-release
-        params:
-          release: winc-release-lock-export-release
-      - put: winc-release-lock-wats
-        params:
-          release: winc-release-lock-wats
-      - put: winc-release-lock-gatsw
-        params:
-          release: winc-release-lock-gatsw
-  on_failure: *release-work-locks
+          release: winc-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -756,25 +705,9 @@ jobs:
     - get: image
     - get: env
     - get: winc-release-env-lock
-    - get: winc-release-lock-prepare-env
-    - get: winc-release-lock-export-release
-    - get: winc-release-lock-wats
-    - get: winc-release-lock-gatsw
-    - put: winc-release-env-lock
-      params:
-        claim: winc-release-env-lock
-    - put: winc-release-lock-prepare-env
-      params:
-        claim: winc-release-lock-prepare-env
-    - put: winc-release-lock-export-release
-      params:
-        claim: winc-release-lock-export-release
-    - put: winc-release-lock-wats
-      params:
-        claim: winc-release-lock-wats
-    - put: winc-release-lock-gatsw
-      params:
-        claim: winc-release-lock-gatsw
+  - put: winc-release-env-lock
+    params:
+      claim: winc-release-env-lock
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -792,12 +725,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: winc-release-lock-prepare-env
-    params:
-      release: winc-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -815,15 +744,7 @@ jobs:
     - get: winc-release
     - get: winc-release-env-lock
       passed: [claim-env]
-    - get: winc-release-lock-prepare-env
-      passed: [claim-env]
-    - get: winc-release-lock-export-release
-      passed: [claim-env]
-    - get: winc-release-lock-wats
-      passed: [claim-env]
-    - get: winc-release-lock-gatsw
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -928,10 +849,6 @@ jobs:
 - name: run-wats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: winc-release-lock-wats
-    params:
-      release: winc-release-lock-wats
   plan:
   - in_parallel:
     - get: ci
@@ -945,8 +862,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: winc-release-lock-wats
-      passed: [prepare-env]
   - task: create-wats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -967,10 +882,6 @@ jobs:
 
 - name: run-gatsw
   serial: true
-  ensure:
-    put: winc-release-lock-gatsw
-    params:
-      release: winc-release-lock-gatsw
   plan:
   - in_parallel:
     - get: ci
@@ -987,8 +898,6 @@ jobs:
     - get: garden-runc-release
     - get: windows-utilities-release
     - get: cf-deployment-concourse-tasks
-    - get: winc-release-lock-gatsw
-      passed: [prepare-env]
   - try:
       do:
         - task: bosh-deld
@@ -1025,10 +934,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: winc-release-lock-export-release
-    params:
-      release: winc-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -1040,8 +945,6 @@ jobs:
       passed: [prepare-env]
       trigger: true
     - get: cf-deployment-concourse-tasks
-    - get: winc-release-lock-export-release
-      passed: [prepare-env]
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -1216,40 +1119,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-    - get: lock-check-timer
-      trigger: true
-      passed: [ cleanup-time-gate ]
-    - get: winc-release-env-lock
-    - get: winc-release-lock-prepare-env
-    - get: winc-release-lock-export-release
-    - get: winc-release-lock-wats
-    - get: winc-release-lock-gatsw
-    - put: check-lock-prepare-env
-      resource: winc-release-lock-prepare-env
-      params:
-        check: winc-release-lock-prepare-env
-        retry-delay: 10m
-    - put: check-lock-export-release
-      resource: winc-release-lock-export-release
-      params:
-        check: winc-release-lock-export-release
-        retry-delay: 10m
-    - put: check-lock-wats
-      resource: winc-release-lock-wats
-      params:
-        check: winc-release-lock-wats
-        retry-delay: 10m
-    - put: check-lock-gatsw
-      resource: winc-release-lock-gatsw
-      params:
-        check: winc-release-lock-gatsw
-        retry-delay: 10m
+  - get: cleanup-timer
+    trigger: true
+    passed: [ cleanup-time-gate ]
+  - get: winc-release-env-lock
+  - put: check-unclaimed-env-lock
+    resource: winc-release-env-lock
+    params:
+      check_unclaimed: winc-release-env-lock
+      retry-delay: 60m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: winc-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 4h
 
 - name: cleanup-env
   serial: true
@@ -1262,101 +1162,44 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: winc-release-env-lock
-        passed: [ check-work-locks ]
-      - get: winc-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: winc-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: winc-release-lock-wats
-        passed: [ check-work-locks ]
-      - get: winc-release-lock-gatsw
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-winc-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-winc-env
-          DEPLOYMENT_NAME: gatsw
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-winc-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: winc-release-env-lock
-        params:
-          release: winc-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: winc-release-lock-prepare-env
-  - put: winc-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: winc-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: winc-release-lock-export-release
-  - put: winc-release-lock-export-release
-    params:
-      release: winc-release-lock-export-release
-
-- name: release-work-lock-wats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: winc-release-lock-wats
-  - put: winc-release-lock-wats
-    params:
-      release: winc-release-lock-wats
-
-- name: release-work-lock-gatsw
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: winc-release-lock-gatsw
-  - put: winc-release-lock-gatsw
-    params:
-      release: winc-release-lock-gatsw
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-winc-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: winc-release-env-lock
-  - put: winc-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: winc-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-winc-env
+      SUSPEND: false
 
 #! versioning
 - name: patch-bump

--- a/windows2019fs-release/pipelines/windows2019fs-release.yml
+++ b/windows2019fs-release/pipelines/windows2019fs-release.yml
@@ -23,13 +23,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-wats
+  - force-cleanup-env
   - release-env-lock
 
 resource_types:
@@ -38,6 +36,11 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -91,7 +94,7 @@ resources:
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: windows2019fs-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -99,36 +102,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: windows2019fs-release-env-lock 
-
-- name: windows2019fs-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windows2019fs-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windows2019fs-release-lock-prepare-env
-
-- name: windows2019fs-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windows2019fs-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windows2019fs-release-lock-export-release
-
-- name: windows2019fs-release-lock-wats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windows2019fs-release-lock-wats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windows2019fs-release-lock-wats
 
 - name: cf-deployment
   type: git
@@ -237,18 +210,13 @@ resources:
     days:
       - Thursday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -263,10 +231,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -395,18 +359,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: windows2019fs-release-lock-prepare-env
+      - put: windows2019fs-release-env-lock
         params:
-          release: windows2019fs-release-lock-prepare-env
-      - put: windows2019fs-release-lock-export-release
-        params:
-          release: windows2019fs-release-lock-export-release
-      - put: windows2019fs-release-lock-wats
-        params:
-          release: windows2019fs-release-lock-wats
-  on_failure: *release-work-locks
+          release: windows2019fs-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -420,22 +378,10 @@ jobs:
     - get: repo
       trigger: true
       passed: [ release-time-gate ]
-  - get: windows2019fs-release-env-lock
-  - get: windows2019fs-release-lock-prepare-env
-  - get: windows2019fs-release-lock-export-release
-  - get: windows2019fs-release-lock-wats
+    - get: windows2019fs-release-env-lock
   - put: windows2019fs-release-env-lock
     params:
       claim: windows2019fs-release-env-lock
-  - put: windows2019fs-release-lock-prepare-env
-    params:
-      claim: windows2019fs-release-lock-prepare-env
-  - put: windows2019fs-release-lock-export-release
-    params:
-      claim: windows2019fs-release-lock-export-release
-  - put: windows2019fs-release-lock-wats
-    params:
-      claim: windows2019fs-release-lock-wats
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -453,12 +399,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: windows2019fs-release-lock-prepare-env
-    params:
-      release: windows2019fs-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -477,12 +419,6 @@ jobs:
       resource: golang-release-latest
     - get: windows2019fs-release-env-lock
       passed: [claim-env]
-    - get: windows2019fs-release-lock-prepare-env
-      passed: [claim-env]
-    - get: windows2019fs-release-lock-export-release
-      passed: [claim-env]
-    - get: windows2019fs-release-lock-wats
-      passed: [claim-env]
   - task: determine-image-tag
     image: image
     file: ci/shared/tasks/determine-image-tag/linux.yml
@@ -490,7 +426,7 @@ jobs:
       PLUGIN: src/code.cloudfoundry.org/hydrator
   - load_var: image_tag
     file: determined-image-tag/tag
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -580,10 +516,6 @@ jobs:
 - name: run-wats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: windows2019fs-release-lock-wats
-    params:
-      release: windows2019fs-release-lock-wats
   plan:
   - in_parallel:
     - get: ci
@@ -599,8 +531,6 @@ jobs:
     - get: cf-deployment-concourse-tasks
     - get: cf-acceptance-tests
     - get: cf-deployment
-    - get: windows2019fs-release-lock-wats
-      passed: [prepare-env]
   - task: create-cats-config
     image: image
     file: ci/shared/tasks/build-acceptance-test-configs/linux.yml
@@ -622,10 +552,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: windows2019fs-release-lock-export-release
-    params:
-      release: windows2019fs-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -639,7 +565,6 @@ jobs:
     - get: windows2016fs
       passed: [prepare-env]
     - get: cf-deployment-concourse-tasks
-    - get: windows2019fs-release-lock-export-release
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -788,34 +713,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: windows2019fs-release-env-lock
-  - get: windows2019fs-release-lock-prepare-env
-  - get: windows2019fs-release-lock-export-release
-  - get: windows2019fs-release-lock-wats
-  - put: check-lock-prepare-env
-    resource: windows2019fs-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: windows2019fs-release-env-lock
     params:
-      check: windows2019fs-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: windows2019fs-release-lock-export-release
-    params:
-      check: windows2019fs-release-lock-export-release
-      retry-delay: 10m
-  - put: check-lock-wats
-    resource: windows2019fs-release-lock-wats
-    params:
-      check: windows2019fs-release-lock-wats
-      retry-delay: 10m
+      check_unclaimed: windows2019fs-release-env-lock
+      retry-delay: 15m
+
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: windows2019fs-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 4h
 
 - name: cleanup-env
   serial: true
@@ -828,78 +756,41 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: windows2019fs-release-env-lock
-        passed: [ check-work-locks ]
-      - get: windows2019fs-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: windows2019fs-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: windows2019fs-release-lock-wats
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-windows2019fs-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-windows2019fs-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: windows2019fs-release-env-lock
-        params:
-          release: windows2019fs-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windows2019fs-release-lock-prepare-env
-  - put: windows2019fs-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: windows2019fs-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windows2019fs-release-lock-export-release
-  - put: windows2019fs-release-lock-export-release
-    params:
-      release: windows2019fs-release-lock-export-release
-
-- name: release-work-lock-wats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windows2019fs-release-lock-wats
-  - put: windows2019fs-release-lock-wats
-    params:
-      release: windows2019fs-release-lock-wats
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-windows2019fs-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: windows2019fs-release-env-lock
-  - put: windows2019fs-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: windows2019fs-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-windows2019fs-env
+      SUSPEND: false

--- a/windowsfs-online-release/pipelines/windowsfs-online-release.yml
+++ b/windowsfs-online-release/pipelines/windowsfs-online-release.yml
@@ -23,13 +23,11 @@ groups:
 - name: cleanup
   jobs:
   - cleanup-time-gate
-  - manual-lock-release-trigger
+  - wait-for-env-lock-claim
+  - wait-for-acceptance-tests
   - manual-cleanup-trigger
-  - check-work-locks
   - cleanup-env
-  - release-work-lock-export-release
-  - release-work-lock-prepare-env
-  - release-work-lock-wats
+  - force-cleanup-env
   - release-env-lock
 
 resource_types:
@@ -39,6 +37,10 @@ resource_types:
     repository: cfcommunity/slack-notification-resource
     tag: latest
 
+- name: fork-pool
+  type: registry-image
+  source:
+    repository: ebroberson/pool-resource
 
 #! Define-Resources
 resources:
@@ -92,7 +94,7 @@ resources:
     uri: https://github.com/cloudfoundry/wg-app-platform-runtime-ci
 
 - name: windowsfs-online-release-env-lock
-  type: pool
+  type: fork-pool
   icon: cloud-lock
   source:
     branch: main
@@ -100,36 +102,6 @@ resources:
     private_key: ((github-appruntimeplatform-bot/private-key))
     uri: git@github.com:cloudfoundry/runtime-ci-pools.git
     paths: windowsfs-online-release-env-lock 
-
-- name: windowsfs-online-release-lock-prepare-env
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windowsfs-online-release-lock-prepare-env
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windowsfs-online-release-lock-prepare-env
-
-- name: windowsfs-online-release-lock-export-release
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windowsfs-online-release-lock-export-release
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windowsfs-online-release-lock-export-release
-
-- name: windowsfs-online-release-lock-wats
-  type: pool
-  icon: cloud-lock
-  source:
-    branch: main
-    pool: windowsfs-online-release-lock-wats
-    private_key: ((github-appruntimeplatform-bot/private-key))
-    uri: git@github.com:cloudfoundry/runtime-ci-pools.git
-    paths: windowsfs-online-release-lock-wats
 
 - name: cf-deployment
   type: git
@@ -239,18 +211,13 @@ resources:
     days:
       - Thursday
 
-- name: lock-check-timer
+- name: cleanup-timer
   type: time
   icon: clock
   source:
     interval: '1h'
 
 - name: manual-release-trigger
-  type: time
-  source:
-    interval: '1m'
-
-- name: manual-lock-release-trigger
   type: time
   source:
     interval: '1m'
@@ -265,10 +232,6 @@ jobs:
 - name: manual-release-trigger
   plan:
   - put: manual-release-trigger
-
-- name: manual-lock-release-trigger
-  plan:
-  - put: manual-lock-release-trigger
 
 - name: manual-cleanup-trigger
   plan:
@@ -376,18 +339,12 @@ jobs:
 
 - name: claim-env
   serial: true
-  on_abort: &release-work-locks
+  on_abort: &release-env-lock
     do:
-      - put: windowsfs-online-release-lock-prepare-env
+      - put: windowsfs-online-release-env-lock
         params:
-          release: windowsfs-online-release-lock-prepare-env
-      - put: windowsfs-online-release-lock-export-release
-        params:
-          release: windowsfs-online-release-lock-export-release
-      - put: windowsfs-online-release-lock-wats
-        params:
-          release: windowsfs-online-release-lock-wats
-  on_failure: *release-work-locks
+          release: windowsfs-online-release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: manual-release-trigger
@@ -401,22 +358,10 @@ jobs:
     - get: env
     - get: windows2016fs
       passed: [ release-time-gate ]
-  - get: windowsfs-online-release-env-lock
-  - get: windowsfs-online-release-lock-prepare-env
-  - get: windowsfs-online-release-lock-export-release
-  - get: windowsfs-online-release-lock-wats
+    - get: windowsfs-online-release-env-lock
   - put: windowsfs-online-release-env-lock
     params:
       claim: windowsfs-online-release-env-lock
-  - put: windowsfs-online-release-lock-prepare-env
-    params:
-      claim: windowsfs-online-release-lock-prepare-env
-  - put: windowsfs-online-release-lock-export-release
-    params:
-      claim: windowsfs-online-release-lock-export-release
-  - put: windowsfs-online-release-lock-wats
-    params:
-      claim: windowsfs-online-release-lock-wats
   - task: start-bbl-envs
     image: image
     file: ci/shared/tasks/start-gcp-instance/linux.yml
@@ -434,12 +379,8 @@ jobs:
 
 - name: prepare-env
   serial: true
-  on_success:
-    put: windowsfs-online-release-lock-prepare-env
-    params:
-      release: windowsfs-online-release-lock-prepare-env
-  on_abort: *release-work-locks
-  on_failure: *release-work-locks
+  on_abort: *release-env-lock
+  on_failure: *release-env-lock
   plan:
   - in_parallel:
     - get: ci
@@ -456,13 +397,7 @@ jobs:
       passed: [claim-env]
     - get: windowsfs-online-release-env-lock
       passed: [claim-env]
-    - get: windowsfs-online-release-lock-prepare-env
-      passed: [claim-env]
-    - get: windowsfs-online-release-lock-export-release
-      passed: [claim-env]
-    - get: windowsfs-online-release-lock-wats
-      passed: [claim-env]
-  - try:
+  - try: &delete-cf-deployment
       do:
         - task: bosh-deld
           image: image
@@ -523,10 +458,6 @@ jobs:
 - name: run-wats
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: windowsfs-online-release-lock-wats
-    params:
-      release: windowsfs-online-release-lock-wats
   plan:
   - in_parallel:
     - get: ci
@@ -541,8 +472,6 @@ jobs:
     - get: cf-acceptance-tests
     - get: cf-deployment
     - get: windows2016fs
-      passed: [prepare-env]
-    - get: windowsfs-online-release-lock-wats
       passed: [prepare-env]
   - task: create-cats-config
     image: image
@@ -565,10 +494,6 @@ jobs:
 - name: export-release
   serial: true
   serial_groups: [acceptance]
-  ensure:
-    put: windowsfs-online-release-lock-export-release
-    params:
-      release: windowsfs-online-release-lock-export-release
   plan:
   - in_parallel:
     - get: ci
@@ -582,7 +507,6 @@ jobs:
     - get: windows2016fs
       passed: [prepare-env]
     - get: cf-deployment-concourse-tasks
-    - get: windowsfs-online-release-lock-export-release
   - task: export-release
     file: ci/shared/tasks/bosh-export-release/linux.yml
     image: image
@@ -734,35 +658,37 @@ jobs:
 
 - name: cleanup-time-gate
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
 
-- name: check-work-locks
+- name: wait-for-env-lock-claim
   serial: true
   plan:
-  - get: lock-check-timer
+  - get: cleanup-timer
     trigger: true
     passed: [ cleanup-time-gate ]
   - get: windowsfs-online-release-env-lock
-  - get: windowsfs-online-release-lock-prepare-env
-  - get: windowsfs-online-release-lock-export-release
-  - get: windowsfs-online-release-lock-wats
-  - put: check-lock-prepare-env
-    resource: windowsfs-online-release-lock-prepare-env
+  - put: check-unclaimed-env-lock
+    resource: windowsfs-online-release-env-lock
     params:
-      check: windowsfs-online-release-lock-prepare-env
-      retry-delay: 10m
-  - put: check-lock-wats
-    resource: windowsfs-online-release-lock-wats
-    params:
-      check: windowsfs-online-release-lock-wats
-      retry-delay: 10m
-  - put: check-lock-export-release
-    resource: windowsfs-online-release-lock-export-release
-    params:
-      check: windowsfs-online-release-lock-export-release
-      retry-delay: 10m
+      check_unclaimed: windowsfs-online-release-env-lock
+      retry-delay: 15m
 
+- name: wait-for-acceptance-tests
+  plan:
+  - get: image
+  - get: windowsfs-online-release-env-lock
+    passed: [ wait-for-env-lock-claim ]
+    trigger: true
+  - task: sleep
+    image: image
+    config:
+      platform: linux
+      run: 
+        path: sh
+        args:
+        - -exc
+        - sleep 4h
 
 - name: cleanup-env
   serial: true
@@ -775,78 +701,41 @@ jobs:
       - get: manual-cleanup-trigger
         trigger: true
         passed: [ manual-cleanup-trigger ]
-      - get: lock-check-timer
-        trigger: true
-        passed: [ check-work-locks ]
       - get: windowsfs-online-release-env-lock
-        passed: [ check-work-locks ]
-      - get: windowsfs-online-release-lock-prepare-env
-        passed: [ check-work-locks ]
-      - get: windowsfs-online-release-lock-export-release
-        passed: [ check-work-locks ]
-      - get: windowsfs-online-release-lock-wats
-        passed: [ check-work-locks ]
-  - try:
-      do:
-      - task: bosh-deld
-        image: image
-        file: ci/shared/tasks/bosh-deld/linux.yml
-        params:
-          BBL_STATE_DIR: bbl-windowsfs-online-env
-          DEPLOYMENT_NAME: cf
-  - try:
-      do:
-      - task: stop-bbl-envs
-        image: image
-        file: ci/shared/tasks/stop-gcp-instance/linux.yml
-        input_mapping:
-          bbl-state: env
-        params:
-          SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
-          BBL_STATE_DIR: bbl-windowsfs-online-env
-          SUSPEND: false
-  - try:
-      do:
-      - put: windowsfs-online-release-env-lock
-        params:
-          release: windowsfs-online-release-env-lock
-
-- name: release-work-lock-prepare-env
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windowsfs-online-release-lock-prepare-env
-  - put: windowsfs-online-release-lock-prepare-env
+        passed: [ wait-for-acceptance-tests ]
+        trigger: true
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: windowsfs-online-release-lock-prepare-env
-
-- name: release-work-lock-export-release
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windowsfs-online-release-lock-export-release
-  - put: windowsfs-online-release-lock-export-release
-    params:
-      release: windowsfs-online-release-lock-export-release
-
-- name: release-work-lock-wats
-  plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
-  - get: windowsfs-online-release-lock-wats
-  - put: windowsfs-online-release-lock-wats
-    params:
-      release: windowsfs-online-release-lock-wats
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-windowsfs-online-env
+      SUSPEND: false
+  - try: *release-env-lock
 
 - name: release-env-lock
   plan:
-  - get: manual-lock-release-trigger
-    trigger: true
-    passed: [ manual-lock-release-trigger ]
   - get: windowsfs-online-release-env-lock
-  - put: windowsfs-online-release-env-lock
+  - try: *release-env-lock
+
+- name: force-cleanup-env
+  serial: true
+  plan:
+  - in_parallel:
+      steps:
+      - get: ci
+      - get: env
+      - get: image
+  - try: *delete-cf-deployment
+  - task: stop-bbl-envs
+    image: image
+    file: ci/shared/tasks/stop-gcp-instance/linux.yml
+    input_mapping:
+      bbl-state: env
     params:
-      release: windowsfs-online-release-env-lock
+      SERVICE_ACCOUNT_KEY: ((gcp-wg-arp-ci-bbl-service-account/config-json))
+      BBL_STATE_DIR: bbl-windowsfs-online-env
+      SUSPEND: false


### PR DESCRIPTION
pool-resource doesn't handle multiple locks well, and it's way too cluttered.

This uses the ebroberson/pool-resource fork which has the `check_unclaimed` feature that will allow us to wait until an environment has been claimed, then a simple `sleep` timer to wait for acceptance tests to complete.