### PR TITLE
fetch release version from the first available deploy

### DIFF
--- a/shared/tasks/bosh-export-release/task.bash
+++ b/shared/tasks/bosh-export-release/task.bash
@@ -21,8 +21,13 @@ function run(){
   local release_name=$(bosh_release_name)
   popd > /dev/null
 
-  local release_version=$(bosh deployments --json | jq -r '.Tables[0].Rows[] | select(.name == "cf") | .release_s' |sed 's/\\n/\n/g' | grep "$release_name" |  cut -d'/' -f2)
-   echo "release version: ${release_version}"
+  local release_version=$(bosh deployments --json | jq -r --arg name "cf" '(first(.Tables[0].Rows[]? | select(.name == $name)) // .Tables[0].Rows[0]? // {}) | .release_s' |sed 's/\\n/\n/g' | grep "$release_name" |  cut -d'/' -f2)
+
+  if [[ -z "$release_version" ]]; then
+    echo "ERROR: Could not find release '$release_name'." >&2
+    exit 1
+  fi
+  echo "release version: ${release_version}"
 
   local release="${release_name}/${release_version}"
 


### PR DESCRIPTION
fetch release version from the first available deployment if one named 'cf' not found.

Test results:
```
~/workspace/app-runtime-platform-envs/bbl-routing-env |main U:1?:6| 
$ release_name=pxc

bosh: bosh-jumpbox501456611/bosh_jumpbox | cf: api.bbl-cfnetworking-env.arp.cloudfoundry.org > outbound-conn-limit-test-org > outbound-conn-limit-test-space (packer-vm) 
~/workspace/app-runtime-platform-envs/bbl-routing-env |main U:1?:6| 
$ bosh deployments --json | jq -r --arg name "cf" '(first(.Tables[0].Rows[]? | select(.name == $name)) // .Tables[0].Rows[0]? // {}) | .release_s' |sed 's/\\n/\n/g' | grep "$release_name" |  cut -d'/' -f2
1.1.2

bosh: bosh-jumpbox501456611/bosh_jumpbox | cf: api.bbl-cfnetworking-env.arp.cloudfoundry.org > outbound-conn-limit-test-org > outbound-conn-limit-test-space (packer-vm) 
~/workspace/app-runtime-platform-envs/bbl-routing-env |main U:1?:6| 
$ bosh deployments --json
{
    "Tables": [
        {
            "Content": "deployments",
            "Header": {
                "name": "Name",
                "release_s": "Release(s)",
                "stemcell_s": "Stemcell(s)",
                "team_s": "Team(s)"
            },
            "Rows": [
                {
                    "name": "cf",
                    "release_s": "backup-and-restore-sdk/1.19.45\nbinary-buildpack/1.1.21\nbosh-dns/1.39.11\nbosh-dns-aliases/0.0.4\nbpm/1.4.20\ncapi/1.213.0\ncf-cli/2.3.0\ncf-networking/3.72.0\ncf-smoke-tests/42.0.218\ncflinuxfs4/1.278.0\ncredhub/2.14.8\ndiego/2.118.0\ndotnet-core-buildpack/2.4.43\ngarden-runc/1.73.0\ngo-buildpack/1.10.38\njava-buildpack/4.77.0\nlog-cache/3.2.0\nloggregator/107.0.21\nloggregator-agent/8.3.8\nnats/56.53.0\nnginx-buildpack/1.2.28\nnodejs-buildpack/1.8.39\nphp-buildpack/4.6.28\npxc/1.1.2\npython-buildpack/1.8.38\nr-buildpack/1.2.22\nrouting/0.342.0\nrouting/0.342.0+dev.1754665198\nruby-buildpack/1.10.25\nsilk/3.72.0\nstaticfile-buildpack/1.6.30\nstatsd-injector/1.11.48\nuaa/78.2.0",
                    "stemcell_s": "bosh-google-kvm-ubuntu-jammy-go_agent/1.866",
                    "team_s": ""
                }
            ],
            "Notes": null
        }
    ],
    "Blocks": null,
    "Lines": [
        "Using environment 'https://10.0.0.6:25555' as client 'admin'",
        "Succeeded"
    ]
}
bosh: bosh-jumpbox501456611/bosh_jumpbox | cf: api.bbl-cfnetworking-env.arp.cloudfoundry.org > outbound-conn-limit-test-org > outbound-conn-limit-test-space (packer-vm) 
~/workspace/app-runtime-platform-envs/bbl-routing-env |main U:1?:6| 
$ bosh deployments --json | jq -r --arg name "cf2" '(first(.Tables[0].Rows[]? | select(.name == $name)) // .Tables[0].Rows[0]? // {}) | .release_s' |sed 's/\\n/\n/g' | grep "$release_name" |  cut -d'/' -f2
1.1.2
```