### PR TITLE
set required cap for ping

### DIFF
--- a/garden-runc-release/dockerfiles/garden-fuse/Dockerfile
+++ b/garden-runc-release/dockerfiles/garden-fuse/Dockerfile
@@ -12,9 +12,13 @@ RUN apt-get update && apt-get -y install \
   gcc \
   attr \
   iputils-ping \
-  pkg-config
+  pkg-config \
+  libcap2-bin 
 
 RUN cd /usr/share/doc/libfuse-dev/examples && \
   bash -c "gcc -Wall hello.c $(pkg-config fuse --cflags --libs) -o /usr/bin/hellofs"
 
+
 RUN useradd -m alice
+# set required capabilitites for raw sockets
+RUN setcap cap_net_raw+ep /usr/bin/ping


### PR DESCRIPTION
set cap for ping was removed https://launchpad.net/ubuntu/+source/iputils/3:20240905-3ubuntu1

https://ci.funtime.lol/teams/wg-arp-garden/pipelines/garden-docker-images/jobs/garden-fuse/builds/33 - this build uses very old version  iputils-ping amd64 3:20221126-1+deb12u1 

https://ci.funtime.lol/teams/wg-arp-garden/pipelines/garden-docker-images/jobs/garden-fuse/builds/34 - latest build got updated.
iputils-ping amd64 3:20240905-3 - it is a huge bump.

```
 Waiting for:
      # file: /usr/bin/ping
      security.capability=0x0100000200200000000000000000000000000000
  In [It] at: /tmp/build/7e717650/repo/src/garden-integration-tests/lifecycle_test.go:1250 @ 09/15/25 22:46:45.437

  Full Stack Trace
```
*****

To avoid this error adding the capability in dockerfile.
Test result:
```
garden-fuse git:(inline-mod-3) ✗ docker run -it 55d /bin/bash
root@a7e68647d1b8:/# 
root@a7e68647d1b8:/# getfattr -d --absolute-names -m - -e hex /usr/bin/ping
# file: /usr/bin/ping
security.capability=0x0100000200200000000000000000000000000000

root@a7e68647d1b8:/# exit
```